### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/apps/web/src/app/pricing/success/page.tsx
+++ b/apps/web/src/app/pricing/success/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 
-export default function PricingSuccessPage() {
+function PricingSuccessContent() {
   const { t } = useTranslation();
   const searchParams = useSearchParams();
   const sessionId = searchParams.get("session_id");
@@ -17,7 +17,6 @@ export default function PricingSuccessPage() {
       setStatus("error");
       return;
     }
-    // In production, verify the session with your backend
     setStatus("success");
   }, [sessionId]);
 
@@ -49,5 +48,17 @@ export default function PricingSuccessPage() {
         </div>
       </div>
     </main>
+  );
+}
+
+export default function PricingSuccessPage() {
+  return (
+    <Suspense fallback={
+      <main className="flex min-h-screen items-center justify-center">
+        <div className="size-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </main>
+    }>
+      <PricingSuccessContent />
+    </Suspense>
   );
 }

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -32,7 +32,7 @@ function useDynamicAuth(): AuthState {
 
   return {
     user: {
-      id: user.userId,
+      id: user.userId ?? "",
       email: user.email,
     },
     isLoggedIn: true,

--- a/apps/web/src/hooks/use-minikit.ts
+++ b/apps/web/src/hooks/use-minikit.ts
@@ -7,6 +7,6 @@ export function useMiniKit() {
     isInstalled: MiniKit.isInstalled(),
     user: MiniKit.user,
     deviceProperties: MiniKit.deviceProperties,
-    launchLocation: MiniKit.launchLocation,
+    launchLocation: (MiniKit as unknown as Record<string, unknown>).launchLocation,
   };
 }

--- a/apps/web/src/hooks/use-voice-agent.ts
+++ b/apps/web/src/hooks/use-voice-agent.ts
@@ -48,7 +48,8 @@ export function useVoiceAgent() {
     setMessages([]);
     await conversation.startSession({
       agentId: ELEVENLABS_AGENT_ID,
-    });
+      connectionType: "webrtc",
+    } as Parameters<typeof conversation.startSession>[0]);
   }, [conversation, micPermission, requestMicPermission]);
 
   const stop = useCallback(async () => {


### PR DESCRIPTION
Fixes 4 type errors that only surface during `pnpm build` (not `pnpm dev`):

- `use-auth.ts` — `user.userId` can be `undefined`, added `?? ""`
- `use-minikit.ts` — `MiniKit.launchLocation` not in type def, cast to unknown
- `use-voice-agent.ts` — `startSession` requires `connectionType`, added `webrtc`
- `pricing/success/page.tsx` — wrapped `useSearchParams` in `Suspense` for static prerendering