### PR TITLE
feat: iOS-style paginated icon carousel for mobile

### DIFF
--- a/apps/os/src/app/page.tsx
+++ b/apps/os/src/app/page.tsx
@@ -6,6 +6,9 @@ import { useTheme } from "@/contexts/theme-context";
 import { getRegistryWindows, getRegistryIcons } from "@/lib/registry-config";
 import type { DesktopConfig } from "@/types";
 
+const APP_HOST = process.env.NEXT_PUBLIC_APP_HOST;
+const CLAWDASH_URL = APP_HOST ? `http://${APP_HOST}:7778` : "http://localhost:7778";
+
 /* ==========================================================================
    APP WINDOW COMPONENTS (static, not from registry)
    ========================================================================== */
@@ -290,9 +293,9 @@ const desktopConfig: DesktopConfig = {
     {
       id: "clawdash",
       type: "browser",
-      title: "http://localhost:7778",
+      title: CLAWDASH_URL,
       icon: <ClawDashTitleIcon />,
-      url: "http://localhost:7778",
+      url: CLAWDASH_URL,
       showReloadButton: true,
       openMaximized: true,
     },

--- a/apps/os/src/components/desktop-icon.tsx
+++ b/apps/os/src/components/desktop-icon.tsx
@@ -14,10 +14,11 @@ export interface DesktopIconProps {
   config: DesktopIconConfig;
   onClick: () => void;
   className?: string;
+  isMobile?: boolean;
 }
 
 export const DesktopIcon = forwardRef<DesktopIconRef, DesktopIconProps>(
-  function DesktopIcon({ config, onClick, className = "" }, ref) {
+  function DesktopIcon({ config, onClick, className = "", isMobile = false }, ref) {
     const { icon, label, initialX = 0, initialY = 0 } = config;
 
     const [position, setPosition] = useState({ x: initialX, y: initialY });
@@ -87,6 +88,39 @@ export const DesktopIcon = forwardRef<DesktopIconRef, DesktopIconProps>(
     const isStringIcon = typeof icon === "string";
     const isElementIcon = isValidElement(icon);
 
+    // iOS-style mobile icon
+    if (isMobile) {
+      return (
+        <div
+          ref={iconRef}
+          onClick={onClick}
+          className="flex flex-col items-center gap-1 select-none active:opacity-70 transition-opacity"
+          style={{ cursor: "pointer" }}
+        >
+          <div
+            className={`pointer-events-none ${isStringIcon ? "text-4xl" : "w-14 h-14 flex items-center justify-center"}`}
+            style={{ filter: "drop-shadow(0 2px 8px rgba(0,0,0,0.5))" }}
+          >
+            {isStringIcon && icon}
+            {isElementIcon && icon}
+          </div>
+          <span
+            className="text-xs text-white text-center font-medium leading-tight pointer-events-none"
+            style={{
+              textShadow: "0 1px 3px rgba(0,0,0,0.9)",
+              maxWidth: "72px",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {label}
+          </span>
+        </div>
+      );
+    }
+
+    // Desktop icon (draggable)
     return (
       <div
         ref={iconRef}

--- a/apps/os/src/components/desktop.tsx
+++ b/apps/os/src/components/desktop.tsx
@@ -270,17 +270,48 @@ function DesktopInner({
           onClick={handleBackgroundClick}
         />
 
-        <div style={getIconContainerStyle()}>
-          {config.icons.map((iconConfig) => (
-            <DesktopIconWrapper
-              key={iconConfig.id}
-              config={iconConfig}
-              onClick={() => handleIconClick(iconConfig.windowId)}
-              onRegisterRef={registerIconRef}
-              isMobile={isMobile}
-            />
-          ))}
-        </div>
+        {isMobile ? (
+          // iOS-style grid layout for mobile
+          <div
+            className="absolute inset-0 z-10 overflow-y-auto"
+            style={{
+              padding: "60px 16px 100px",
+              transition: "opacity 0.4s ease-out",
+              opacity: showIcons ? 1 : 0,
+            }}
+          >
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(4, 1fr)",
+                gap: "24px 8px",
+              }}
+            >
+              {config.icons.map((iconConfig) => (
+                <DesktopIconWrapper
+                  key={iconConfig.id}
+                  config={iconConfig}
+                  onClick={() => handleIconClick(iconConfig.windowId)}
+                  onRegisterRef={registerIconRef}
+                  isMobile={isMobile}
+                />
+              ))}
+            </div>
+          </div>
+        ) : (
+          // Desktop vertical sidebar
+          <div style={getIconContainerStyle()}>
+            {config.icons.map((iconConfig) => (
+              <DesktopIconWrapper
+                key={iconConfig.id}
+                config={iconConfig}
+                onClick={() => handleIconClick(iconConfig.windowId)}
+                onRegisterRef={registerIconRef}
+                isMobile={isMobile}
+              />
+            ))}
+          </div>
+        )}
 
         {Array.from(windowManager.windows.values()).map((instance) => {
           const iconConfig = config.icons.find(
@@ -323,6 +354,7 @@ function DesktopIconWrapper({
   config,
   onClick,
   onRegisterRef,
+  isMobile,
 }: DesktopIconWrapperProps) {
   const ref = useRef<DesktopIconRef>(null);
 
@@ -330,5 +362,5 @@ function DesktopIconWrapper({
     onRegisterRef(config.id, ref);
   }, [config.id, onRegisterRef]);
 
-  return <DesktopIcon ref={ref} config={config} onClick={onClick} />;
+  return <DesktopIcon ref={ref} config={config} onClick={onClick} isMobile={isMobile} />;
 }

--- a/apps/os/src/components/desktop.tsx
+++ b/apps/os/src/components/desktop.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/contexts/theme-context";
 import { useWindowManager } from "@/hooks/use-window-manager";
 import { DesktopIcon } from "@/components/desktop-icon";
+import { MobileIconCarousel } from "@/components/mobile-icon-carousel";
 import { Window } from "@/components/window";
 
 export interface DesktopProps {
@@ -271,32 +272,13 @@ function DesktopInner({
         />
 
         {isMobile ? (
-          // iOS-style grid layout for mobile
-          <div
-            className="absolute inset-0 z-10 overflow-y-auto"
-            style={{
-              padding: "60px 16px 100px",
-              transition: "opacity 0.4s ease-out",
-              opacity: showIcons ? 1 : 0,
-            }}
-          >
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "repeat(4, 1fr)",
-                gap: "24px 8px",
-              }}
-            >
-              {config.icons.map((iconConfig) => (
-                <DesktopIconWrapper
-                  key={iconConfig.id}
-                  config={iconConfig}
-                  onClick={() => handleIconClick(iconConfig.windowId)}
-                  onRegisterRef={registerIconRef}
-                  isMobile={isMobile}
-                />
-              ))}
-            </div>
+          // iOS-style paginated carousel for mobile
+          <div style={{ opacity: showIcons ? 1 : 0, transition: "opacity 0.4s ease-out", position: "absolute", inset: 0, zIndex: 10 }}>
+            <MobileIconCarousel
+              icons={config.icons}
+              onIconClick={handleIconClick}
+              onRegisterRef={registerIconRef}
+            />
           </div>
         ) : (
           // Desktop vertical sidebar

--- a/apps/os/src/components/mobile-icon-carousel.tsx
+++ b/apps/os/src/components/mobile-icon-carousel.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState, useRef, useCallback, type RefObject } from "react";
+import type { DesktopIconConfig, DesktopIconRef } from "@/types";
+import { DesktopIcon } from "@/components/desktop-icon";
+
+const ICONS_PER_PAGE = 24; // 4 cols × 6 rows
+
+interface MobileIconCarouselProps {
+  icons: DesktopIconConfig[];
+  onIconClick: (windowId: string) => void;
+  onRegisterRef: (iconId: string, ref: RefObject<DesktopIconRef | null>) => void;
+}
+
+export function MobileIconCarousel({
+  icons,
+  onIconClick,
+  onRegisterRef,
+}: MobileIconCarouselProps) {
+  const pages = Math.ceil(icons.length / ICONS_PER_PAGE);
+  const [currentPage, setCurrentPage] = useState(0);
+
+  // Touch tracking
+  const touchStartX = useRef(0);
+  const touchStartY = useRef(0);
+  const isDragging = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const goToPage = useCallback((page: number) => {
+    setCurrentPage(Math.max(0, Math.min(pages - 1, page)));
+  }, [pages]);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0]?.clientX ?? 0;
+    touchStartY.current = e.touches[0]?.clientY ?? 0;
+    isDragging.current = false;
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    const deltaX = Math.abs((e.touches[0]?.clientX ?? 0) - touchStartX.current);
+    const deltaY = Math.abs((e.touches[0]?.clientY ?? 0) - touchStartY.current);
+    if (deltaX > deltaY && deltaX > 10) {
+      isDragging.current = true;
+    }
+  }, []);
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (!isDragging.current) return;
+    const deltaX = (e.changedTouches[0]?.clientX ?? 0) - touchStartX.current;
+    const threshold = 60;
+    if (deltaX < -threshold) goToPage(currentPage + 1);
+    else if (deltaX > threshold) goToPage(currentPage - 1);
+  }, [currentPage, goToPage]);
+
+  // Mouse swipe fallback for desktop testing
+  const mouseStartX = useRef(0);
+  const isMouseDragging = useRef(false);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    mouseStartX.current = e.clientX;
+    isMouseDragging.current = true;
+  }, []);
+
+  const handleMouseUp = useCallback((e: React.MouseEvent) => {
+    if (!isMouseDragging.current) return;
+    isMouseDragging.current = false;
+    const deltaX = e.clientX - mouseStartX.current;
+    const threshold = 60;
+    if (deltaX < -threshold) goToPage(currentPage + 1);
+    else if (deltaX > threshold) goToPage(currentPage - 1);
+  }, [currentPage, goToPage]);
+
+  return (
+    <div className="absolute inset-0 flex flex-col z-10" style={{ paddingTop: 60, paddingBottom: 80 }}>
+      {/* Carousel viewport */}
+      <div
+        ref={containerRef}
+        className="flex-1 overflow-hidden relative"
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        style={{ userSelect: "none" }}
+      >
+        {/* Sliding track */}
+        <div
+          className="flex h-full"
+          style={{
+            width: `${pages * 100}%`,
+            transform: `translateX(-${(currentPage / pages) * 100}%)`,
+            transition: "transform 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94)",
+          }}
+        >
+          {Array.from({ length: pages }).map((_, pageIndex) => {
+            const pageIcons = icons.slice(
+              pageIndex * ICONS_PER_PAGE,
+              (pageIndex + 1) * ICONS_PER_PAGE
+            );
+            return (
+              <div
+                key={pageIndex}
+                className="h-full flex-shrink-0"
+                style={{ width: `${100 / pages}%`, padding: "0 16px" }}
+              >
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(4, 1fr)",
+                    gridTemplateRows: "repeat(6, 1fr)",
+                    gap: "8px",
+                    height: "100%",
+                  }}
+                >
+                  {pageIcons.map((iconConfig) => (
+                    <IconCell
+                      key={iconConfig.id}
+                      config={iconConfig}
+                      onClick={() => onIconClick(iconConfig.windowId)}
+                      onRegisterRef={onRegisterRef}
+                    />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Page indicator dots */}
+      {pages > 1 && (
+        <div className="flex items-center justify-center gap-2 pb-2">
+          {Array.from({ length: pages }).map((_, i) => (
+            <button
+              key={i}
+              onClick={() => goToPage(i)}
+              style={{
+                width: i === currentPage ? 20 : 6,
+                height: 6,
+                borderRadius: 3,
+                backgroundColor: i === currentPage ? "rgba(255,255,255,0.95)" : "rgba(255,255,255,0.4)",
+                transition: "all 0.2s ease",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+              }}
+              aria-label={`Page ${i + 1}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IconCell({
+  config,
+  onClick,
+  onRegisterRef,
+}: {
+  config: DesktopIconConfig;
+  onClick: () => void;
+  onRegisterRef: (iconId: string, ref: RefObject<DesktopIconRef | null>) => void;
+}) {
+  const ref = useRef<DesktopIconRef>(null);
+
+  // Register ref on mount
+  const callbackRef = useCallback((el: DesktopIconRef | null) => {
+    (ref as React.MutableRefObject<DesktopIconRef | null>).current = el;
+    if (el) onRegisterRef(config.id, ref);
+  }, [config.id, onRegisterRef]);
+
+  return (
+    <div className="flex items-center justify-center">
+      <DesktopIcon
+        ref={ref}
+        config={config}
+        onClick={onClick}
+        isMobile
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Replaces the scrollable mobile icon grid with a proper iPhone-style home screen carousel:

- **4×6 grid per page** (24 icons)
- **Swipe left/right** to navigate pages (touch + mouse)
- **Smooth snap animation** between pages
- **Pill dot indicators** at the bottom — active page shows a wider pill
- Desktop layout completely unchanged