### PR TITLE
feat: add Blueprint OpenClaw skill

### DIFF
--- a/.agents/skills/blueprint/SKILL.md
+++ b/.agents/skills/blueprint/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: blueprint
+description: Build with Blueprint OS — a full-stack Turborepo monorepo (Next.js 15, Fastify, Expo, Drizzle, shadcn/ui, Tailwind v4). Use when working in a Blueprint repository, scaffolding Blueprint apps, adding features to Blueprint projects, or when the user mentions Blueprint OS. Covers architecture, how apps relate, scaffolding, and ecosystem-level knowledge.
+---
+
+## If Working in a Blueprint Repo
+
+If you have the Blueprint repo cloned, read these files FIRST — they are authoritative:
+1. `CLAUDE.md` at repo root
+2. All `.mdc` files in `.claude/rules/`
+3. All `.mdc` files in `.agents/rules/`
+
+This skill provides supplementary ecosystem context. The repo rules are the source of truth for code standards.
+
+# Blueprint OS
+
+Blueprint is a production-ready Turborepo monorepo for building full-stack apps with AI agents.
+
+## Architecture
+
+```
+blueprint/
+├── apps/
+│   ├── web/            → Next.js 15 + shadcn/ui + Tailwind CSS v4       :3000
+│   ├── admin/          → Next.js 15 + shadcn/ui + Tailwind CSS v4       :3002
+│   ├── docs/           → Mintlify documentation                         :3003
+│   ├── react-native/   → Expo + Expo Router + NativeWind
+│   ├── remotion/       → Remotion video generation                      :3004
+│   ├── os/             → Desktop environment (Next.js 15 + shadcn/ui)   :7777
+│   ├── clawdash/       → OpenClaw diagnostics dashboard                 :7778
+│   └── server/         → Fastify + Swagger API server                   :3001
+├── packages/
+│   ├── app-config/     → Centralized branding, metadata, assets (SSOT)
+│   ├── blueprint-cli/  → npx blueprint CLI
+│   ├── db/             → Drizzle ORM + Neon PostgreSQL
+│   ├── eslint-config/  → Shared ESLint
+│   └── typescript-config/ → Shared TSConfig
+├── prompts/            → AI prompt library
+```
+
+## How Apps Relate
+
+- **web** is the main consumer-facing app; **admin** is the internal management panel. Both share the same API server and database.
+- **react-native** mirrors web features using NativeWind equivalents of shadcn/ui. Features must ship to both simultaneously.
+- **server** is the shared Fastify API backend — all frontend apps consume it via React Query hooks.
+- **app-config** is the single source of truth for branding, metadata, and assets. All apps import from `@repo/app-config`. Run `pnpm sync-config` after changes.
+- **db** holds all Drizzle ORM schemas. All apps share this package for types and queries.
+- **docs** is Mintlify-powered documentation for the project.
+- **remotion** generates branded video content using app-config for colors/logos.
+- **os** is a macOS-style desktop environment UI.
+- **clawdash** is the OpenClaw agent diagnostics dashboard.
+- **blueprint-cli** (`npx blueprint`) scaffolds new Blueprint projects with optional features.
+
+## Essential Commands
+
+```bash
+pnpm install              # Install deps (always pnpm, never npm/yarn)
+pnpm dev                  # Start all apps
+pnpm dev:<app>            # Start one app (web, admin, server, os, clawdash)
+pnpm build                # Build all
+pnpm lint && pnpm check-types  # Pre-commit checks
+pnpm db:generate          # Generate Drizzle migrations
+pnpm db:push              # Push schema to database
+pnpm sync-config          # Sync app-config → all apps (theme, assets, OG)
+```
+
+**Runtime:** Node.js >= 23 (`.nvmrc` provided), pnpm 10.
+
+## Scaffolding with the CLI
+
+`npx blueprint new` scaffolds a new project with interactive feature selection:
+
+- **Apps:** web (always included), admin, docs, react-native, remotion
+- **Database:** Drizzle + Neon PostgreSQL (optional)
+- **Auth:** Dynamic (email OTP) or Privy (email, social, wallets) — mutually exclusive
+- **Payments:** Stripe integration
+- **Integrations:** World MiniApp (MiniKit), ElevenLabs voice, analytics
+- **Web features:** i18n, PWA support
+
+Features are gated by environment variables — unconfigured features show fallback UI or unlock everything (Stripe).
+
+## Detailed References
+
+For deeper ecosystem patterns, see:
+
+- **[references/patterns.md](references/patterns.md)** — API schema examples, database conventions, component mapping, testing and performance patterns
+- **[references/integrations.md](references/integrations.md)** — Auth (Dynamic/Privy), Stripe payments, World MiniApp, ElevenLabs voice, feature gating
+- **[references/governance.md](references/governance.md)** — Agent hard boundaries, git workflow, deployment, asset storage

--- a/.agents/skills/blueprint/references/governance.md
+++ b/.agents/skills/blueprint/references/governance.md
@@ -1,0 +1,44 @@
+# Blueprint Agent Governance
+
+> When working in a Blueprint repo, `CLAUDE.md` and `.claude/rules/*.mdc` are authoritative.
+> This file provides governance context for agents working outside the repo.
+
+## Hard Boundaries
+
+1. **DO NOT** delete, rename, or restructure existing apps or packages
+2. **DO NOT** modify `turbo.json`, `pnpm-workspace.yaml`, or root `package.json` without explicit approval
+3. **DO NOT** modify `.env` files or commit secrets
+4. **DO NOT** force-push to `main`
+5. **DO NOT** run destructive commands (`rm -rf`, `drop table`) on production data
+
+## What Agents CAN Do
+
+- **Add apps**: New directory under `apps/`, add to `apps-registry.ts` and root `package.json`
+- **Edit code**: Fix bugs, add features — always on feature branches
+- **Run commands**: `pnpm install`, `pnpm build`, `pnpm dev:*`, `pnpm db:push`, `pnpm db:generate`
+- **Git**: Create branches, commit (conventional), push feature branches, create PRs
+- **Download assets**: Save to `storage/` (images/, videos/, documents/, temp/)
+- **Rebuild**: `pnpm build --filter=<app>` then `pm2 restart <app>`
+
+## Git Workflow
+
+- Always work on feature branches — never commit to `main`
+- Branch prefix by agent: `ocean/`, `arctic/`, `ash/`, `skylar/`
+- Conventional commits: `feat(web):`, `fix(server):`, `chore(db):`
+- One concern per PR
+- Never merge without explicit approval from the project owner
+
+## Deployment
+
+```bash
+pnpm install            # if deps changed
+pnpm build              # or pnpm build --filter=<app>
+pm2 restart <app> --update-env
+```
+
+## Production Infrastructure
+
+- **Process manager**: PM2 (`ecosystem.config.cjs`)
+- **Reverse proxy**: Caddy (auto-HTTPS via Let's Encrypt)
+- **Private access**: Tailscale for admin, OS, and gateway
+- **App registry**: `packages/app-config/src/apps-registry.ts`

--- a/.agents/skills/blueprint/references/integrations.md
+++ b/.agents/skills/blueprint/references/integrations.md
@@ -1,0 +1,51 @@
+# Blueprint Integrations Reference
+
+> When working in a Blueprint repo, the `.claude/rules/*.mdc` files are authoritative.
+> This file provides ecosystem-level integration context.
+
+## Authentication
+
+Two mutually exclusive auth providers, chosen during CLI scaffolding.
+
+### Dynamic Auth (Email OTP)
+
+- **Web**: `DynamicContextProvider` from `@dynamic-labs/sdk-react-core`
+- **React Native**: `createClient` from `@dynamic-labs/client` + `ReactNativeExtension`
+- **Server**: JWT via JWKS (RS256), upserts via `dynamic_user_id`
+- **Env**: `NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID`, `EXPO_PUBLIC_DYNAMIC_ENVIRONMENT_ID`, `DYNAMIC_ENVIRONMENT_ID`
+- Feature flag: `dynamicEnabled` in `lib/dynamic.ts`
+
+### Privy Auth (Email, Social, Wallets)
+
+- **Web**: `PrivyProvider` from `@privy-io/react-auth`
+- **React Native**: `PrivyProvider` from `@privy-io/expo`
+- **Server**: JWT via `@privy-io/node` (ES256), upserts via `privy_user_id`
+- **Env**: `NEXT_PUBLIC_PRIVY_APP_ID`, `EXPO_PUBLIC_PRIVY_APP_ID`, `PRIVY_APP_ID` + `PRIVY_APP_SECRET`
+- Feature flag: `privyEnabled` in `lib/privy.ts`
+
+Both expose `useAuth()`: `{ user, isLoggedIn, getToken }`. Send JWT as `Authorization: Bearer <token>`. Never use NextAuth, Clerk, or other auth libs.
+
+## Stripe Payments
+
+- **Web**: `@stripe/react-stripe-js` + `@stripe/stripe-js` (Checkout Sessions)
+- **React Native**: `@stripe/stripe-react-native` (PaymentSheet)
+- **Server**: `stripe` Node SDK in `apps/server/src/routes/stripe.ts`
+- Feature flag: `stripeEnabled` — when unconfigured, all features unlocked
+
+### Feature Gating
+
+Tiers in `lib/features.ts`: `free` (default), `pro` (paid). Use `hasFeature(tier, key)` and `useSubscription()` hook. Always enforce server-side.
+
+## World Mini App (MiniKit)
+
+Runs inside World App webview. Guard with `MiniKit.isInstalled()`. Backend verification at `src/app/api/minikit/`. Auth via Wallet Auth (SIWE). Display `MiniKit.user.username`, not raw addresses.
+
+- Payments: WLD/USDC on World Chain, minimum $0.1, whitelist recipients in Developer Portal
+- Design: 24px padding, `100dvh`, bottom tab navigation only, no `alert()`/`confirm()`
+
+## ElevenLabs Voice Agent
+
+- **Web**: `@elevenlabs/react` — `useConversation`
+- **React Native**: `@elevenlabs/react-native` — `ElevenLabsProvider` + `useConversation`
+- Feature flag: `elevenlabsEnabled` in `lib/elevenlabs.ts`
+- Use `useVoiceAgent()` wrapper. Check flag before rendering voice UI.

--- a/.agents/skills/blueprint/references/patterns.md
+++ b/.agents/skills/blueprint/references/patterns.md
@@ -1,0 +1,62 @@
+# Blueprint Patterns Reference
+
+> When working in a Blueprint repo, the `.claude/rules/*.mdc` files are authoritative.
+> This file provides quick-reference examples for use outside the repo context.
+
+## API Pattern (Fastify + Swagger)
+
+Routes live in `apps/server/src/routes/`, registered in `apps/server/src/app.ts`.
+
+```typescript
+// apps/server/src/routes/users.ts
+export default async function usersRoutes(app: FastifyInstance) {
+  app.get("/users/:id", {
+    schema: {
+      params: { type: "object", properties: { id: { type: "string", format: "uuid" } }, required: ["id"] },
+      response: { 200: { type: "object", properties: { id: { type: "string" }, email: { type: "string" } } } }
+    }
+  }, async (request, reply) => { /* handler */ });
+}
+```
+
+Every endpoint MUST include a Fastify schema for Swagger (`http://localhost:3001/docs`).
+
+## React Query Hooks
+
+One hook per file in `src/hooks/`. Naming: `useGet[Resource]`, `useList[Resources]`, `use[Verb][Resource]`.
+
+```typescript
+// src/hooks/use-get-user.ts
+export function useGetUser(id: string) {
+  return useQuery({ queryKey: ["user", id], queryFn: () => api.get(`/users/${id}`) });
+}
+```
+
+## Database Schema
+
+```typescript
+// packages/db/src/schema/posts.ts
+export const posts = pgTable("posts", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  title: text("title").notNull(),
+  userId: uuid("user_id").notNull().references(() => users.id),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+```
+
+Conventions: plural snake_case tables, snake_case columns, always `id`/`createdAt`/`updatedAt`.
+
+## Co-Development Component Mapping
+
+| Web (shadcn/ui)     | React Native (NativeWind)                |
+|---------------------|------------------------------------------|
+| `<Button>`          | `<TouchableOpacity className="...">`     |
+| `<Card>`            | `<View className="...">`                 |
+| `<Input>`           | `<TextInput className="...">`            |
+| `<Dialog>`          | `<Modal>`                                |
+| Next.js `<Link>`    | Expo Router `<Link>`                     |
+
+## Mobile Web Components
+
+On viewports < 768px, `apps/web` uses: `MobileTopNav`, `MobileFooter`, `MobileLayout`, `BottomSheet` (vaul), `SlideInSheet`. Use `useIsMobile()` hook and `md:hidden`/`md:block`.

--- a/.claude/skills/blueprint/SKILL.md
+++ b/.claude/skills/blueprint/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: blueprint
+description: Build with Blueprint OS — a full-stack Turborepo monorepo (Next.js 15, Fastify, Expo, Drizzle, shadcn/ui, Tailwind v4). Use when working in a Blueprint repository, scaffolding Blueprint apps, adding features to Blueprint projects, or when the user mentions Blueprint OS. Covers architecture, how apps relate, scaffolding, and ecosystem-level knowledge.
+---
+
+## If Working in a Blueprint Repo
+
+If you have the Blueprint repo cloned, read these files FIRST — they are authoritative:
+1. `CLAUDE.md` at repo root
+2. All `.mdc` files in `.claude/rules/`
+3. All `.mdc` files in `.agents/rules/`
+
+This skill provides supplementary ecosystem context. The repo rules are the source of truth for code standards.
+
+# Blueprint OS
+
+Blueprint is a production-ready Turborepo monorepo for building full-stack apps with AI agents.
+
+## Architecture
+
+```
+blueprint/
+├── apps/
+│   ├── web/            → Next.js 15 + shadcn/ui + Tailwind CSS v4       :3000
+│   ├── admin/          → Next.js 15 + shadcn/ui + Tailwind CSS v4       :3002
+│   ├── docs/           → Mintlify documentation                         :3003
+│   ├── react-native/   → Expo + Expo Router + NativeWind
+│   ├── remotion/       → Remotion video generation                      :3004
+│   ├── os/             → Desktop environment (Next.js 15 + shadcn/ui)   :7777
+│   ├── clawdash/       → OpenClaw diagnostics dashboard                 :7778
+│   └── server/         → Fastify + Swagger API server                   :3001
+├── packages/
+│   ├── app-config/     → Centralized branding, metadata, assets (SSOT)
+│   ├── blueprint-cli/  → npx blueprint CLI
+│   ├── db/             → Drizzle ORM + Neon PostgreSQL
+│   ├── eslint-config/  → Shared ESLint
+│   └── typescript-config/ → Shared TSConfig
+├── prompts/            → AI prompt library
+```
+
+## How Apps Relate
+
+- **web** is the main consumer-facing app; **admin** is the internal management panel. Both share the same API server and database.
+- **react-native** mirrors web features using NativeWind equivalents of shadcn/ui. Features must ship to both simultaneously.
+- **server** is the shared Fastify API backend — all frontend apps consume it via React Query hooks.
+- **app-config** is the single source of truth for branding, metadata, and assets. All apps import from `@repo/app-config`. Run `pnpm sync-config` after changes.
+- **db** holds all Drizzle ORM schemas. All apps share this package for types and queries.
+- **docs** is Mintlify-powered documentation for the project.
+- **remotion** generates branded video content using app-config for colors/logos.
+- **os** is a macOS-style desktop environment UI.
+- **clawdash** is the OpenClaw agent diagnostics dashboard.
+- **blueprint-cli** (`npx blueprint`) scaffolds new Blueprint projects with optional features.
+
+## Essential Commands
+
+```bash
+pnpm install              # Install deps (always pnpm, never npm/yarn)
+pnpm dev                  # Start all apps
+pnpm dev:<app>            # Start one app (web, admin, server, os, clawdash)
+pnpm build                # Build all
+pnpm lint && pnpm check-types  # Pre-commit checks
+pnpm db:generate          # Generate Drizzle migrations
+pnpm db:push              # Push schema to database
+pnpm sync-config          # Sync app-config → all apps (theme, assets, OG)
+```
+
+**Runtime:** Node.js >= 23 (`.nvmrc` provided), pnpm 10.
+
+## Scaffolding with the CLI
+
+`npx blueprint new` scaffolds a new project with interactive feature selection:
+
+- **Apps:** web (always included), admin, docs, react-native, remotion
+- **Database:** Drizzle + Neon PostgreSQL (optional)
+- **Auth:** Dynamic (email OTP) or Privy (email, social, wallets) — mutually exclusive
+- **Payments:** Stripe integration
+- **Integrations:** World MiniApp (MiniKit), ElevenLabs voice, analytics
+- **Web features:** i18n, PWA support
+
+Features are gated by environment variables — unconfigured features show fallback UI or unlock everything (Stripe).
+
+## Detailed References
+
+For deeper ecosystem patterns, see:
+
+- **[references/patterns.md](references/patterns.md)** — API schema examples, database conventions, component mapping, testing and performance patterns
+- **[references/integrations.md](references/integrations.md)** — Auth (Dynamic/Privy), Stripe payments, World MiniApp, ElevenLabs voice, feature gating
+- **[references/governance.md](references/governance.md)** — Agent hard boundaries, git workflow, deployment, asset storage

--- a/.claude/skills/blueprint/references/governance.md
+++ b/.claude/skills/blueprint/references/governance.md
@@ -1,0 +1,44 @@
+# Blueprint Agent Governance
+
+> When working in a Blueprint repo, `CLAUDE.md` and `.claude/rules/*.mdc` are authoritative.
+> This file provides governance context for agents working outside the repo.
+
+## Hard Boundaries
+
+1. **DO NOT** delete, rename, or restructure existing apps or packages
+2. **DO NOT** modify `turbo.json`, `pnpm-workspace.yaml`, or root `package.json` without explicit approval
+3. **DO NOT** modify `.env` files or commit secrets
+4. **DO NOT** force-push to `main`
+5. **DO NOT** run destructive commands (`rm -rf`, `drop table`) on production data
+
+## What Agents CAN Do
+
+- **Add apps**: New directory under `apps/`, add to `apps-registry.ts` and root `package.json`
+- **Edit code**: Fix bugs, add features — always on feature branches
+- **Run commands**: `pnpm install`, `pnpm build`, `pnpm dev:*`, `pnpm db:push`, `pnpm db:generate`
+- **Git**: Create branches, commit (conventional), push feature branches, create PRs
+- **Download assets**: Save to `storage/` (images/, videos/, documents/, temp/)
+- **Rebuild**: `pnpm build --filter=<app>` then `pm2 restart <app>`
+
+## Git Workflow
+
+- Always work on feature branches — never commit to `main`
+- Branch prefix by agent: `ocean/`, `arctic/`, `ash/`, `skylar/`
+- Conventional commits: `feat(web):`, `fix(server):`, `chore(db):`
+- One concern per PR
+- Never merge without explicit approval from the project owner
+
+## Deployment
+
+```bash
+pnpm install            # if deps changed
+pnpm build              # or pnpm build --filter=<app>
+pm2 restart <app> --update-env
+```
+
+## Production Infrastructure
+
+- **Process manager**: PM2 (`ecosystem.config.cjs`)
+- **Reverse proxy**: Caddy (auto-HTTPS via Let's Encrypt)
+- **Private access**: Tailscale for admin, OS, and gateway
+- **App registry**: `packages/app-config/src/apps-registry.ts`

--- a/.claude/skills/blueprint/references/integrations.md
+++ b/.claude/skills/blueprint/references/integrations.md
@@ -1,0 +1,51 @@
+# Blueprint Integrations Reference
+
+> When working in a Blueprint repo, the `.claude/rules/*.mdc` files are authoritative.
+> This file provides ecosystem-level integration context.
+
+## Authentication
+
+Two mutually exclusive auth providers, chosen during CLI scaffolding.
+
+### Dynamic Auth (Email OTP)
+
+- **Web**: `DynamicContextProvider` from `@dynamic-labs/sdk-react-core`
+- **React Native**: `createClient` from `@dynamic-labs/client` + `ReactNativeExtension`
+- **Server**: JWT via JWKS (RS256), upserts via `dynamic_user_id`
+- **Env**: `NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID`, `EXPO_PUBLIC_DYNAMIC_ENVIRONMENT_ID`, `DYNAMIC_ENVIRONMENT_ID`
+- Feature flag: `dynamicEnabled` in `lib/dynamic.ts`
+
+### Privy Auth (Email, Social, Wallets)
+
+- **Web**: `PrivyProvider` from `@privy-io/react-auth`
+- **React Native**: `PrivyProvider` from `@privy-io/expo`
+- **Server**: JWT via `@privy-io/node` (ES256), upserts via `privy_user_id`
+- **Env**: `NEXT_PUBLIC_PRIVY_APP_ID`, `EXPO_PUBLIC_PRIVY_APP_ID`, `PRIVY_APP_ID` + `PRIVY_APP_SECRET`
+- Feature flag: `privyEnabled` in `lib/privy.ts`
+
+Both expose `useAuth()`: `{ user, isLoggedIn, getToken }`. Send JWT as `Authorization: Bearer <token>`. Never use NextAuth, Clerk, or other auth libs.
+
+## Stripe Payments
+
+- **Web**: `@stripe/react-stripe-js` + `@stripe/stripe-js` (Checkout Sessions)
+- **React Native**: `@stripe/stripe-react-native` (PaymentSheet)
+- **Server**: `stripe` Node SDK in `apps/server/src/routes/stripe.ts`
+- Feature flag: `stripeEnabled` — when unconfigured, all features unlocked
+
+### Feature Gating
+
+Tiers in `lib/features.ts`: `free` (default), `pro` (paid). Use `hasFeature(tier, key)` and `useSubscription()` hook. Always enforce server-side.
+
+## World Mini App (MiniKit)
+
+Runs inside World App webview. Guard with `MiniKit.isInstalled()`. Backend verification at `src/app/api/minikit/`. Auth via Wallet Auth (SIWE). Display `MiniKit.user.username`, not raw addresses.
+
+- Payments: WLD/USDC on World Chain, minimum $0.1, whitelist recipients in Developer Portal
+- Design: 24px padding, `100dvh`, bottom tab navigation only, no `alert()`/`confirm()`
+
+## ElevenLabs Voice Agent
+
+- **Web**: `@elevenlabs/react` — `useConversation`
+- **React Native**: `@elevenlabs/react-native` — `ElevenLabsProvider` + `useConversation`
+- Feature flag: `elevenlabsEnabled` in `lib/elevenlabs.ts`
+- Use `useVoiceAgent()` wrapper. Check flag before rendering voice UI.

--- a/.claude/skills/blueprint/references/patterns.md
+++ b/.claude/skills/blueprint/references/patterns.md
@@ -1,0 +1,62 @@
+# Blueprint Patterns Reference
+
+> When working in a Blueprint repo, the `.claude/rules/*.mdc` files are authoritative.
+> This file provides quick-reference examples for use outside the repo context.
+
+## API Pattern (Fastify + Swagger)
+
+Routes live in `apps/server/src/routes/`, registered in `apps/server/src/app.ts`.
+
+```typescript
+// apps/server/src/routes/users.ts
+export default async function usersRoutes(app: FastifyInstance) {
+  app.get("/users/:id", {
+    schema: {
+      params: { type: "object", properties: { id: { type: "string", format: "uuid" } }, required: ["id"] },
+      response: { 200: { type: "object", properties: { id: { type: "string" }, email: { type: "string" } } } }
+    }
+  }, async (request, reply) => { /* handler */ });
+}
+```
+
+Every endpoint MUST include a Fastify schema for Swagger (`http://localhost:3001/docs`).
+
+## React Query Hooks
+
+One hook per file in `src/hooks/`. Naming: `useGet[Resource]`, `useList[Resources]`, `use[Verb][Resource]`.
+
+```typescript
+// src/hooks/use-get-user.ts
+export function useGetUser(id: string) {
+  return useQuery({ queryKey: ["user", id], queryFn: () => api.get(`/users/${id}`) });
+}
+```
+
+## Database Schema
+
+```typescript
+// packages/db/src/schema/posts.ts
+export const posts = pgTable("posts", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  title: text("title").notNull(),
+  userId: uuid("user_id").notNull().references(() => users.id),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+```
+
+Conventions: plural snake_case tables, snake_case columns, always `id`/`createdAt`/`updatedAt`.
+
+## Co-Development Component Mapping
+
+| Web (shadcn/ui)     | React Native (NativeWind)                |
+|---------------------|------------------------------------------|
+| `<Button>`          | `<TouchableOpacity className="...">`     |
+| `<Card>`            | `<View className="...">`                 |
+| `<Input>`           | `<TextInput className="...">`            |
+| `<Dialog>`          | `<Modal>`                                |
+| Next.js `<Link>`    | Expo Router `<Link>`                     |
+
+## Mobile Web Components
+
+On viewports < 768px, `apps/web` uses: `MobileTopNav`, `MobileFooter`, `MobileLayout`, `BottomSheet` (vaul), `SlideInSheet`. Use `useIsMobile()` hook and `md:hidden`/`md:block`.

--- a/.cursor/skills/blueprint/SKILL.md
+++ b/.cursor/skills/blueprint/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: blueprint
+description: Build with Blueprint OS — a full-stack Turborepo monorepo (Next.js 15, Fastify, Expo, Drizzle, shadcn/ui, Tailwind v4). Use when working in a Blueprint repository, scaffolding Blueprint apps, adding features to Blueprint projects, or when the user mentions Blueprint OS. Covers architecture, how apps relate, scaffolding, and ecosystem-level knowledge.
+---
+
+## If Working in a Blueprint Repo
+
+If you have the Blueprint repo cloned, read these files FIRST — they are authoritative:
+1. `CLAUDE.md` at repo root
+2. All `.mdc` files in `.claude/rules/`
+3. All `.mdc` files in `.agents/rules/`
+
+This skill provides supplementary ecosystem context. The repo rules are the source of truth for code standards.
+
+# Blueprint OS
+
+Blueprint is a production-ready Turborepo monorepo for building full-stack apps with AI agents.
+
+## Architecture
+
+```
+blueprint/
+├── apps/
+│   ├── web/            → Next.js 15 + shadcn/ui + Tailwind CSS v4       :3000
+│   ├── admin/          → Next.js 15 + shadcn/ui + Tailwind CSS v4       :3002
+│   ├── docs/           → Mintlify documentation                         :3003
+│   ├── react-native/   → Expo + Expo Router + NativeWind
+│   ├── remotion/       → Remotion video generation                      :3004
+│   ├── os/             → Desktop environment (Next.js 15 + shadcn/ui)   :7777
+│   ├── clawdash/       → OpenClaw diagnostics dashboard                 :7778
+│   └── server/         → Fastify + Swagger API server                   :3001
+├── packages/
+│   ├── app-config/     → Centralized branding, metadata, assets (SSOT)
+│   ├── blueprint-cli/  → npx blueprint CLI
+│   ├── db/             → Drizzle ORM + Neon PostgreSQL
+│   ├── eslint-config/  → Shared ESLint
+│   └── typescript-config/ → Shared TSConfig
+├── prompts/            → AI prompt library
+```
+
+## How Apps Relate
+
+- **web** is the main consumer-facing app; **admin** is the internal management panel. Both share the same API server and database.
+- **react-native** mirrors web features using NativeWind equivalents of shadcn/ui. Features must ship to both simultaneously.
+- **server** is the shared Fastify API backend — all frontend apps consume it via React Query hooks.
+- **app-config** is the single source of truth for branding, metadata, and assets. All apps import from `@repo/app-config`. Run `pnpm sync-config` after changes.
+- **db** holds all Drizzle ORM schemas. All apps share this package for types and queries.
+- **docs** is Mintlify-powered documentation for the project.
+- **remotion** generates branded video content using app-config for colors/logos.
+- **os** is a macOS-style desktop environment UI.
+- **clawdash** is the OpenClaw agent diagnostics dashboard.
+- **blueprint-cli** (`npx blueprint`) scaffolds new Blueprint projects with optional features.
+
+## Essential Commands
+
+```bash
+pnpm install              # Install deps (always pnpm, never npm/yarn)
+pnpm dev                  # Start all apps
+pnpm dev:<app>            # Start one app (web, admin, server, os, clawdash)
+pnpm build                # Build all
+pnpm lint && pnpm check-types  # Pre-commit checks
+pnpm db:generate          # Generate Drizzle migrations
+pnpm db:push              # Push schema to database
+pnpm sync-config          # Sync app-config → all apps (theme, assets, OG)
+```
+
+**Runtime:** Node.js >= 23 (`.nvmrc` provided), pnpm 10.
+
+## Scaffolding with the CLI
+
+`npx blueprint new` scaffolds a new project with interactive feature selection:
+
+- **Apps:** web (always included), admin, docs, react-native, remotion
+- **Database:** Drizzle + Neon PostgreSQL (optional)
+- **Auth:** Dynamic (email OTP) or Privy (email, social, wallets) — mutually exclusive
+- **Payments:** Stripe integration
+- **Integrations:** World MiniApp (MiniKit), ElevenLabs voice, analytics
+- **Web features:** i18n, PWA support
+
+Features are gated by environment variables — unconfigured features show fallback UI or unlock everything (Stripe).
+
+## Detailed References
+
+For deeper ecosystem patterns, see:
+
+- **[references/patterns.md](references/patterns.md)** — API schema examples, database conventions, component mapping, testing and performance patterns
+- **[references/integrations.md](references/integrations.md)** — Auth (Dynamic/Privy), Stripe payments, World MiniApp, ElevenLabs voice, feature gating
+- **[references/governance.md](references/governance.md)** — Agent hard boundaries, git workflow, deployment, asset storage

--- a/.cursor/skills/blueprint/references/governance.md
+++ b/.cursor/skills/blueprint/references/governance.md
@@ -1,0 +1,44 @@
+# Blueprint Agent Governance
+
+> When working in a Blueprint repo, `CLAUDE.md` and `.claude/rules/*.mdc` are authoritative.
+> This file provides governance context for agents working outside the repo.
+
+## Hard Boundaries
+
+1. **DO NOT** delete, rename, or restructure existing apps or packages
+2. **DO NOT** modify `turbo.json`, `pnpm-workspace.yaml`, or root `package.json` without explicit approval
+3. **DO NOT** modify `.env` files or commit secrets
+4. **DO NOT** force-push to `main`
+5. **DO NOT** run destructive commands (`rm -rf`, `drop table`) on production data
+
+## What Agents CAN Do
+
+- **Add apps**: New directory under `apps/`, add to `apps-registry.ts` and root `package.json`
+- **Edit code**: Fix bugs, add features — always on feature branches
+- **Run commands**: `pnpm install`, `pnpm build`, `pnpm dev:*`, `pnpm db:push`, `pnpm db:generate`
+- **Git**: Create branches, commit (conventional), push feature branches, create PRs
+- **Download assets**: Save to `storage/` (images/, videos/, documents/, temp/)
+- **Rebuild**: `pnpm build --filter=<app>` then `pm2 restart <app>`
+
+## Git Workflow
+
+- Always work on feature branches — never commit to `main`
+- Branch prefix by agent: `ocean/`, `arctic/`, `ash/`, `skylar/`
+- Conventional commits: `feat(web):`, `fix(server):`, `chore(db):`
+- One concern per PR
+- Never merge without explicit approval from the project owner
+
+## Deployment
+
+```bash
+pnpm install            # if deps changed
+pnpm build              # or pnpm build --filter=<app>
+pm2 restart <app> --update-env
+```
+
+## Production Infrastructure
+
+- **Process manager**: PM2 (`ecosystem.config.cjs`)
+- **Reverse proxy**: Caddy (auto-HTTPS via Let's Encrypt)
+- **Private access**: Tailscale for admin, OS, and gateway
+- **App registry**: `packages/app-config/src/apps-registry.ts`

--- a/.cursor/skills/blueprint/references/integrations.md
+++ b/.cursor/skills/blueprint/references/integrations.md
@@ -1,0 +1,51 @@
+# Blueprint Integrations Reference
+
+> When working in a Blueprint repo, the `.claude/rules/*.mdc` files are authoritative.
+> This file provides ecosystem-level integration context.
+
+## Authentication
+
+Two mutually exclusive auth providers, chosen during CLI scaffolding.
+
+### Dynamic Auth (Email OTP)
+
+- **Web**: `DynamicContextProvider` from `@dynamic-labs/sdk-react-core`
+- **React Native**: `createClient` from `@dynamic-labs/client` + `ReactNativeExtension`
+- **Server**: JWT via JWKS (RS256), upserts via `dynamic_user_id`
+- **Env**: `NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID`, `EXPO_PUBLIC_DYNAMIC_ENVIRONMENT_ID`, `DYNAMIC_ENVIRONMENT_ID`
+- Feature flag: `dynamicEnabled` in `lib/dynamic.ts`
+
+### Privy Auth (Email, Social, Wallets)
+
+- **Web**: `PrivyProvider` from `@privy-io/react-auth`
+- **React Native**: `PrivyProvider` from `@privy-io/expo`
+- **Server**: JWT via `@privy-io/node` (ES256), upserts via `privy_user_id`
+- **Env**: `NEXT_PUBLIC_PRIVY_APP_ID`, `EXPO_PUBLIC_PRIVY_APP_ID`, `PRIVY_APP_ID` + `PRIVY_APP_SECRET`
+- Feature flag: `privyEnabled` in `lib/privy.ts`
+
+Both expose `useAuth()`: `{ user, isLoggedIn, getToken }`. Send JWT as `Authorization: Bearer <token>`. Never use NextAuth, Clerk, or other auth libs.
+
+## Stripe Payments
+
+- **Web**: `@stripe/react-stripe-js` + `@stripe/stripe-js` (Checkout Sessions)
+- **React Native**: `@stripe/stripe-react-native` (PaymentSheet)
+- **Server**: `stripe` Node SDK in `apps/server/src/routes/stripe.ts`
+- Feature flag: `stripeEnabled` — when unconfigured, all features unlocked
+
+### Feature Gating
+
+Tiers in `lib/features.ts`: `free` (default), `pro` (paid). Use `hasFeature(tier, key)` and `useSubscription()` hook. Always enforce server-side.
+
+## World Mini App (MiniKit)
+
+Runs inside World App webview. Guard with `MiniKit.isInstalled()`. Backend verification at `src/app/api/minikit/`. Auth via Wallet Auth (SIWE). Display `MiniKit.user.username`, not raw addresses.
+
+- Payments: WLD/USDC on World Chain, minimum $0.1, whitelist recipients in Developer Portal
+- Design: 24px padding, `100dvh`, bottom tab navigation only, no `alert()`/`confirm()`
+
+## ElevenLabs Voice Agent
+
+- **Web**: `@elevenlabs/react` — `useConversation`
+- **React Native**: `@elevenlabs/react-native` — `ElevenLabsProvider` + `useConversation`
+- Feature flag: `elevenlabsEnabled` in `lib/elevenlabs.ts`
+- Use `useVoiceAgent()` wrapper. Check flag before rendering voice UI.

--- a/.cursor/skills/blueprint/references/patterns.md
+++ b/.cursor/skills/blueprint/references/patterns.md
@@ -1,0 +1,62 @@
+# Blueprint Patterns Reference
+
+> When working in a Blueprint repo, the `.claude/rules/*.mdc` files are authoritative.
+> This file provides quick-reference examples for use outside the repo context.
+
+## API Pattern (Fastify + Swagger)
+
+Routes live in `apps/server/src/routes/`, registered in `apps/server/src/app.ts`.
+
+```typescript
+// apps/server/src/routes/users.ts
+export default async function usersRoutes(app: FastifyInstance) {
+  app.get("/users/:id", {
+    schema: {
+      params: { type: "object", properties: { id: { type: "string", format: "uuid" } }, required: ["id"] },
+      response: { 200: { type: "object", properties: { id: { type: "string" }, email: { type: "string" } } } }
+    }
+  }, async (request, reply) => { /* handler */ });
+}
+```
+
+Every endpoint MUST include a Fastify schema for Swagger (`http://localhost:3001/docs`).
+
+## React Query Hooks
+
+One hook per file in `src/hooks/`. Naming: `useGet[Resource]`, `useList[Resources]`, `use[Verb][Resource]`.
+
+```typescript
+// src/hooks/use-get-user.ts
+export function useGetUser(id: string) {
+  return useQuery({ queryKey: ["user", id], queryFn: () => api.get(`/users/${id}`) });
+}
+```
+
+## Database Schema
+
+```typescript
+// packages/db/src/schema/posts.ts
+export const posts = pgTable("posts", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  title: text("title").notNull(),
+  userId: uuid("user_id").notNull().references(() => users.id),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+```
+
+Conventions: plural snake_case tables, snake_case columns, always `id`/`createdAt`/`updatedAt`.
+
+## Co-Development Component Mapping
+
+| Web (shadcn/ui)     | React Native (NativeWind)                |
+|---------------------|------------------------------------------|
+| `<Button>`          | `<TouchableOpacity className="...">`     |
+| `<Card>`            | `<View className="...">`                 |
+| `<Input>`           | `<TextInput className="...">`            |
+| `<Dialog>`          | `<Modal>`                                |
+| Next.js `<Link>`    | Expo Router `<Link>`                     |
+
+## Mobile Web Components
+
+On viewports < 768px, `apps/web` uses: `MobileTopNav`, `MobileFooter`, `MobileLayout`, `BottomSheet` (vaul), `SlideInSheet`. Use `useIsMobile()` hook and `md:hidden`/`md:block`.

--- a/.openclaw/skill/blueprint/SKILL.md
+++ b/.openclaw/skill/blueprint/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: blueprint
+description: Build with Blueprint OS — a full-stack Turborepo monorepo (Next.js 15, Fastify, Expo, Drizzle, shadcn/ui, Tailwind v4). Use when working in a Blueprint repository, scaffolding Blueprint apps, adding features to Blueprint projects, or when the user mentions Blueprint OS. Covers architecture, how apps relate, scaffolding, and ecosystem-level knowledge.
+---
+
+## If Working in a Blueprint Repo
+
+If you have the Blueprint repo cloned, read these files FIRST — they are authoritative:
+1. `CLAUDE.md` at repo root
+2. All `.mdc` files in `.claude/rules/`
+3. All `.mdc` files in `.agents/rules/`
+
+This skill provides supplementary ecosystem context. The repo rules are the source of truth for code standards.
+
+# Blueprint OS
+
+Blueprint is a production-ready Turborepo monorepo for building full-stack apps with AI agents.
+
+## Architecture
+
+```
+blueprint/
+├── apps/
+│   ├── web/            → Next.js 15 + shadcn/ui + Tailwind CSS v4       :3000
+│   ├── admin/          → Next.js 15 + shadcn/ui + Tailwind CSS v4       :3002
+│   ├── docs/           → Mintlify documentation                         :3003
+│   ├── react-native/   → Expo + Expo Router + NativeWind
+│   ├── remotion/       → Remotion video generation                      :3004
+│   ├── os/             → Desktop environment (Next.js 15 + shadcn/ui)   :7777
+│   ├── clawdash/       → OpenClaw diagnostics dashboard                 :7778
+│   └── server/         → Fastify + Swagger API server                   :3001
+├── packages/
+│   ├── app-config/     → Centralized branding, metadata, assets (SSOT)
+│   ├── blueprint-cli/  → npx blueprint CLI
+│   ├── db/             → Drizzle ORM + Neon PostgreSQL
+│   ├── eslint-config/  → Shared ESLint
+│   └── typescript-config/ → Shared TSConfig
+├── prompts/            → AI prompt library
+```
+
+## How Apps Relate
+
+- **web** is the main consumer-facing app; **admin** is the internal management panel. Both share the same API server and database.
+- **react-native** mirrors web features using NativeWind equivalents of shadcn/ui. Features must ship to both simultaneously.
+- **server** is the shared Fastify API backend — all frontend apps consume it via React Query hooks.
+- **app-config** is the single source of truth for branding, metadata, and assets. All apps import from `@repo/app-config`. Run `pnpm sync-config` after changes.
+- **db** holds all Drizzle ORM schemas. All apps share this package for types and queries.
+- **docs** is Mintlify-powered documentation for the project.
+- **remotion** generates branded video content using app-config for colors/logos.
+- **os** is a macOS-style desktop environment UI.
+- **clawdash** is the OpenClaw agent diagnostics dashboard.
+- **blueprint-cli** (`npx blueprint`) scaffolds new Blueprint projects with optional features.
+
+## Essential Commands
+
+```bash
+pnpm install              # Install deps (always pnpm, never npm/yarn)
+pnpm dev                  # Start all apps
+pnpm dev:<app>            # Start one app (web, admin, server, os, clawdash)
+pnpm build                # Build all
+pnpm lint && pnpm check-types  # Pre-commit checks
+pnpm db:generate          # Generate Drizzle migrations
+pnpm db:push              # Push schema to database
+pnpm sync-config          # Sync app-config → all apps (theme, assets, OG)
+```
+
+**Runtime:** Node.js >= 23 (`.nvmrc` provided), pnpm 10.
+
+## Scaffolding with the CLI
+
+`npx blueprint new` scaffolds a new project with interactive feature selection:
+
+- **Apps:** web (always included), admin, docs, react-native, remotion
+- **Database:** Drizzle + Neon PostgreSQL (optional)
+- **Auth:** Dynamic (email OTP) or Privy (email, social, wallets) — mutually exclusive
+- **Payments:** Stripe integration
+- **Integrations:** World MiniApp (MiniKit), ElevenLabs voice, analytics
+- **Web features:** i18n, PWA support
+
+Features are gated by environment variables — unconfigured features show fallback UI or unlock everything (Stripe).
+
+## Detailed References
+
+For deeper ecosystem patterns, see:
+
+- **[references/patterns.md](references/patterns.md)** — API schema examples, database conventions, component mapping, testing and performance patterns
+- **[references/integrations.md](references/integrations.md)** — Auth (Dynamic/Privy), Stripe payments, World MiniApp, ElevenLabs voice, feature gating
+- **[references/governance.md](references/governance.md)** — Agent hard boundaries, git workflow, deployment, asset storage

--- a/.openclaw/skill/blueprint/references/governance.md
+++ b/.openclaw/skill/blueprint/references/governance.md
@@ -1,0 +1,44 @@
+# Blueprint Agent Governance
+
+> When working in a Blueprint repo, `CLAUDE.md` and `.claude/rules/*.mdc` are authoritative.
+> This file provides governance context for agents working outside the repo.
+
+## Hard Boundaries
+
+1. **DO NOT** delete, rename, or restructure existing apps or packages
+2. **DO NOT** modify `turbo.json`, `pnpm-workspace.yaml`, or root `package.json` without explicit approval
+3. **DO NOT** modify `.env` files or commit secrets
+4. **DO NOT** force-push to `main`
+5. **DO NOT** run destructive commands (`rm -rf`, `drop table`) on production data
+
+## What Agents CAN Do
+
+- **Add apps**: New directory under `apps/`, add to `apps-registry.ts` and root `package.json`
+- **Edit code**: Fix bugs, add features — always on feature branches
+- **Run commands**: `pnpm install`, `pnpm build`, `pnpm dev:*`, `pnpm db:push`, `pnpm db:generate`
+- **Git**: Create branches, commit (conventional), push feature branches, create PRs
+- **Download assets**: Save to `storage/` (images/, videos/, documents/, temp/)
+- **Rebuild**: `pnpm build --filter=<app>` then `pm2 restart <app>`
+
+## Git Workflow
+
+- Always work on feature branches — never commit to `main`
+- Branch prefix by agent: `ocean/`, `arctic/`, `ash/`, `skylar/`
+- Conventional commits: `feat(web):`, `fix(server):`, `chore(db):`
+- One concern per PR
+- Never merge without explicit approval from the project owner
+
+## Deployment
+
+```bash
+pnpm install            # if deps changed
+pnpm build              # or pnpm build --filter=<app>
+pm2 restart <app> --update-env
+```
+
+## Production Infrastructure
+
+- **Process manager**: PM2 (`ecosystem.config.cjs`)
+- **Reverse proxy**: Caddy (auto-HTTPS via Let's Encrypt)
+- **Private access**: Tailscale for admin, OS, and gateway
+- **App registry**: `packages/app-config/src/apps-registry.ts`

--- a/.openclaw/skill/blueprint/references/integrations.md
+++ b/.openclaw/skill/blueprint/references/integrations.md
@@ -1,0 +1,51 @@
+# Blueprint Integrations Reference
+
+> When working in a Blueprint repo, the `.claude/rules/*.mdc` files are authoritative.
+> This file provides ecosystem-level integration context.
+
+## Authentication
+
+Two mutually exclusive auth providers, chosen during CLI scaffolding.
+
+### Dynamic Auth (Email OTP)
+
+- **Web**: `DynamicContextProvider` from `@dynamic-labs/sdk-react-core`
+- **React Native**: `createClient` from `@dynamic-labs/client` + `ReactNativeExtension`
+- **Server**: JWT via JWKS (RS256), upserts via `dynamic_user_id`
+- **Env**: `NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID`, `EXPO_PUBLIC_DYNAMIC_ENVIRONMENT_ID`, `DYNAMIC_ENVIRONMENT_ID`
+- Feature flag: `dynamicEnabled` in `lib/dynamic.ts`
+
+### Privy Auth (Email, Social, Wallets)
+
+- **Web**: `PrivyProvider` from `@privy-io/react-auth`
+- **React Native**: `PrivyProvider` from `@privy-io/expo`
+- **Server**: JWT via `@privy-io/node` (ES256), upserts via `privy_user_id`
+- **Env**: `NEXT_PUBLIC_PRIVY_APP_ID`, `EXPO_PUBLIC_PRIVY_APP_ID`, `PRIVY_APP_ID` + `PRIVY_APP_SECRET`
+- Feature flag: `privyEnabled` in `lib/privy.ts`
+
+Both expose `useAuth()`: `{ user, isLoggedIn, getToken }`. Send JWT as `Authorization: Bearer <token>`. Never use NextAuth, Clerk, or other auth libs.
+
+## Stripe Payments
+
+- **Web**: `@stripe/react-stripe-js` + `@stripe/stripe-js` (Checkout Sessions)
+- **React Native**: `@stripe/stripe-react-native` (PaymentSheet)
+- **Server**: `stripe` Node SDK in `apps/server/src/routes/stripe.ts`
+- Feature flag: `stripeEnabled` — when unconfigured, all features unlocked
+
+### Feature Gating
+
+Tiers in `lib/features.ts`: `free` (default), `pro` (paid). Use `hasFeature(tier, key)` and `useSubscription()` hook. Always enforce server-side.
+
+## World Mini App (MiniKit)
+
+Runs inside World App webview. Guard with `MiniKit.isInstalled()`. Backend verification at `src/app/api/minikit/`. Auth via Wallet Auth (SIWE). Display `MiniKit.user.username`, not raw addresses.
+
+- Payments: WLD/USDC on World Chain, minimum $0.1, whitelist recipients in Developer Portal
+- Design: 24px padding, `100dvh`, bottom tab navigation only, no `alert()`/`confirm()`
+
+## ElevenLabs Voice Agent
+
+- **Web**: `@elevenlabs/react` — `useConversation`
+- **React Native**: `@elevenlabs/react-native` — `ElevenLabsProvider` + `useConversation`
+- Feature flag: `elevenlabsEnabled` in `lib/elevenlabs.ts`
+- Use `useVoiceAgent()` wrapper. Check flag before rendering voice UI.

--- a/.openclaw/skill/blueprint/references/patterns.md
+++ b/.openclaw/skill/blueprint/references/patterns.md
@@ -1,0 +1,62 @@
+# Blueprint Patterns Reference
+
+> When working in a Blueprint repo, the `.claude/rules/*.mdc` files are authoritative.
+> This file provides quick-reference examples for use outside the repo context.
+
+## API Pattern (Fastify + Swagger)
+
+Routes live in `apps/server/src/routes/`, registered in `apps/server/src/app.ts`.
+
+```typescript
+// apps/server/src/routes/users.ts
+export default async function usersRoutes(app: FastifyInstance) {
+  app.get("/users/:id", {
+    schema: {
+      params: { type: "object", properties: { id: { type: "string", format: "uuid" } }, required: ["id"] },
+      response: { 200: { type: "object", properties: { id: { type: "string" }, email: { type: "string" } } } }
+    }
+  }, async (request, reply) => { /* handler */ });
+}
+```
+
+Every endpoint MUST include a Fastify schema for Swagger (`http://localhost:3001/docs`).
+
+## React Query Hooks
+
+One hook per file in `src/hooks/`. Naming: `useGet[Resource]`, `useList[Resources]`, `use[Verb][Resource]`.
+
+```typescript
+// src/hooks/use-get-user.ts
+export function useGetUser(id: string) {
+  return useQuery({ queryKey: ["user", id], queryFn: () => api.get(`/users/${id}`) });
+}
+```
+
+## Database Schema
+
+```typescript
+// packages/db/src/schema/posts.ts
+export const posts = pgTable("posts", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  title: text("title").notNull(),
+  userId: uuid("user_id").notNull().references(() => users.id),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+```
+
+Conventions: plural snake_case tables, snake_case columns, always `id`/`createdAt`/`updatedAt`.
+
+## Co-Development Component Mapping
+
+| Web (shadcn/ui)     | React Native (NativeWind)                |
+|---------------------|------------------------------------------|
+| `<Button>`          | `<TouchableOpacity className="...">`     |
+| `<Card>`            | `<View className="...">`                 |
+| `<Input>`           | `<TextInput className="...">`            |
+| `<Dialog>`          | `<Modal>`                                |
+| Next.js `<Link>`    | Expo Router `<Link>`                     |
+
+## Mobile Web Components
+
+On viewports < 768px, `apps/web` uses: `MobileTopNav`, `MobileFooter`, `MobileLayout`, `BottomSheet` (vaul), `SlideInSheet`. Use `useIsMobile()` hook and `md:hidden`/`md:block`.


### PR DESCRIPTION
## What

Adds the Blueprint ecosystem skill for OpenClaw agents.

## Structure

Skill is placed at `.openclaw/skill/blueprint/` and synced to `.agents/skills/`, `.claude/skills/`, and `.cursor/skills/` per the 018-skill-sync rule.

```
blueprint/
├── SKILL.md
└── references/
    ├── patterns.md
    ├── integrations.md
    └── governance.md
```

## Design Decisions

- **Ecosystem over code-level**: The skill covers what Blueprint IS, how apps relate, scaffolding, and integration overview. Code standards (style, git, testing, etc.) are left to the repo rules (`.claude/rules/*.mdc`).
- **Repo-first directive**: SKILL.md starts with a section directing agents to read `CLAUDE.md` and repo rules first when working in a cloned repo.
- **Trimmed references**: Reference files are condensed quick-references, not full duplicates of repo rules. They note that repo rules are authoritative.

## Checklist

- [x] Skill synced to all 4 directories
- [x] No duplication of code-level standards from repo rules
- [x] "If Working in a Blueprint Repo" section added as first section after frontmatter