### PR TITLE
feat(infra): paperclip PM2 + Caddy production config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ storage/documents/*
 storage/temp/*
 !storage/**/.gitkeep
 
-# PM2
-ecosystem.config.cjs
+# PM2 ecosystem config is tracked in git (see ecosystem.config.cjs)
 
 apps/remotion/build.env.local

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -1,0 +1,24 @@
+# Caddy Config Snippets
+
+These files are per-app Caddy reverse proxy configurations.
+
+## Apply to production
+
+Copy the relevant blocks into `/etc/caddy/Caddyfile`, replacing `{$BLUEPRINT_DOMAIN}` with the actual domain (e.g., `blueprintos.com`):
+
+```caddyfile
+paperclip.blueprintos.com {
+    reverse_proxy localhost:3100
+}
+```
+
+Then reload Caddy:
+```bash
+sudo systemctl reload caddy
+```
+
+## Port security note
+
+Port 3100 (and all internal app ports) do NOT need to be open in the AWS Security Group.
+Caddy handles TLS termination on ports 80/443 and routes traffic to internal ports.
+Only ports 80 and 443 need to be publicly accessible.

--- a/caddy/paperclip.conf
+++ b/caddy/paperclip.conf
@@ -1,0 +1,10 @@
+# Paperclip reverse proxy config
+# Include in /etc/caddy/Caddyfile or use `import caddy/*.conf`
+#
+# Paperclip runs internally on port 3100.
+# Port 3100 does NOT need to be opened in the AWS Security Group —
+# Caddy terminates TLS on 443 and forwards traffic internally.
+
+paperclip.{$BLUEPRINT_DOMAIN} {
+    reverse_proxy localhost:3100
+}

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,94 @@
+/**
+ * PM2 Ecosystem Config
+ * Manages all Blueprint OS apps on the VPS.
+ *
+ * Usage:
+ *   pm2 start ecosystem.config.cjs       # Start all apps
+ *   pm2 restart ecosystem.config.cjs     # Restart all apps
+ *   pm2 reload ecosystem.config.cjs      # Zero-downtime reload
+ */
+
+module.exports = {
+  apps: [
+    {
+      name: "web",
+      script: "npx",
+      args: "next start -p 3000",
+      cwd: "/home/deploy/repos/blueprint/apps/web",
+      env: {
+        NODE_ENV: "production",
+        PORT: "3000",
+      },
+    },
+    {
+      name: "server",
+      script: "npx",
+      args: "tsx src/index.ts",
+      cwd: "/home/deploy/repos/blueprint/apps/server",
+      env: {
+        NODE_ENV: "production",
+        PORT: "3001",
+      },
+    },
+    {
+      name: "admin",
+      script: "npx",
+      args: "next start -p 3002",
+      cwd: "/home/deploy/repos/blueprint/apps/admin",
+      env: {
+        NODE_ENV: "production",
+        PORT: "3002",
+      },
+    },
+    {
+      name: "docs",
+      script: "npx",
+      args: "mintlify dev --port 3003",
+      cwd: "/home/deploy/repos/blueprint/apps/docs",
+      env: {
+        NODE_ENV: "production",
+        PORT: "3003",
+      },
+    },
+    {
+      name: "remotion",
+      script: "npx",
+      args: "remotion studio --port 3004 --no-open",
+      cwd: "/home/deploy/repos/blueprint/apps/remotion",
+      env: {
+        NODE_ENV: "production",
+        PORT: "3004",
+      },
+    },
+    {
+      name: "clawdash",
+      script: "npx",
+      args: "next start -p 3005",
+      cwd: "/home/deploy/repos/blueprint/apps/clawdash",
+      env: {
+        NODE_ENV: "production",
+        PORT: "3005",
+      },
+    },
+    {
+      name: "paperclip",
+      script: "pnpm",
+      args: "dev",
+      cwd: "/home/deploy/repos/blueprint/apps/paperclip",
+      env: {
+        NODE_ENV: "development",
+        PORT: "3100",
+      },
+    },
+    {
+      name: "os",
+      script: "npx",
+      args: "next start -p 7777",
+      cwd: "/home/deploy/repos/blueprint/apps/os",
+      env: {
+        NODE_ENV: "production",
+        PORT: "7777",
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Sets up Paperclip for production on the Blueprint server.

## Changes

### 1. `ecosystem.config.cjs` (new file)
- Creates the PM2 ecosystem config at the repo root (previously gitignored/absent)
- Adds all existing apps (web, server, admin, docs, remotion, clawdash, os) to match current running state
- Adds **paperclip** entry:
  - `cwd`: `/home/deploy/repos/blueprint/apps/paperclip`
  - `script`: `pnpm`
  - `args`: `dev`
  - `PORT`: `3100`

### 2. `.gitignore`
- Removes `ecosystem.config.cjs` from gitignore so it can be tracked and managed via PRs

### 3. `caddy/paperclip.conf` (new file)
- Reverse proxy config: `paperclip.{$BLUEPRINT_DOMAIN}` → `localhost:3100`
- Matches the pattern of other app subdomain proxies

### 4. `caddy/README.md` (new file)
- Instructions for applying config snippets to `/etc/caddy/Caddyfile`

## AWS Security Group

✅ **Port 3100 does NOT need to be opened publicly.** Caddy handles TLS termination on ports 80/443 and forwards traffic to internal ports. Only ports 80 and 443 need to be accessible in the Security Group.

## tsx Patch (Node v24 compat)

✅ Already present. `apps/paperclip/server/node_modules/tsx/package.json` includes `"./dist/cli.mjs"` in its exports — the Node v24 compat patch from Ocean's branch is in place.

## How to apply Caddy config

```bash
# Add to /etc/caddy/Caddyfile:
ppaperclip.blueprintos.com {
    reverse_proxy localhost:3100
}

# Then reload:
sudo systemctl reload caddy
```

## How to start paperclip via PM2

```bash
cd /home/deploy/repos/blueprint
pm2 start ecosystem.config.cjs --only paperclip
# or restart all:
pm2 restart ecosystem.config.cjs
```