### PR TITLE
fix(os): add missing ClawDash to OS app registry

### DIFF
--- a/apps/os/src/lib/registry-config.tsx
+++ b/apps/os/src/lib/registry-config.tsx
@@ -90,6 +90,10 @@ const SVG_PATHS: Record<string, { desktop: ReactNode; titleBar: ReactNode }> = {
       </>
     ),
   },
+  activity: {
+    desktop: <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />,
+    titleBar: <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />,
+  },
 };
 
 const DEFAULT_COLORS = { from: "from-zinc-600", to: "to-zinc-800", text: "text-zinc-400" } as const;
@@ -100,6 +104,7 @@ const COLOR_MAP: Record<string, { from: string; to: string; text: string }> = {
   violet: { from: "from-violet-500", to: "to-purple-700", text: "text-violet-400" },
   emerald: { from: "from-emerald-500", to: "to-teal-600", text: "text-emerald-400" },
   pink: { from: "from-pink-500", to: "to-rose-600", text: "text-pink-400" },
+  amber: { from: "from-amber-500", to: "to-orange-600", text: "text-amber-400" },
   zinc: DEFAULT_COLORS,
 };
 

--- a/packages/app-config/src/apps-registry.ts
+++ b/packages/app-config/src/apps-registry.ts
@@ -10,7 +10,7 @@ export interface AppEntry {
   /** "public" apps are exposed via Caddy; "private" are Tailscale-only */
   access: "public" | "private";
   /** Whether this is a Next.js app managed by PM2 */
-  type: "nextjs" | "fastify" | "mintlify" | "remotion" | "expo";
+  type: "nextjs" | "fastify" | "mintlify" | "remotion" | "expo" | "standalone";
 }
 
 export const appsRegistry: AppEntry[] = [
@@ -73,6 +73,18 @@ export const appsRegistry: AppEntry[] = [
     openMaximized: true,
     access: "private",
     type: "remotion",
+  },
+  {
+    id: "clawdash",
+    name: "ClawDash",
+    port: 7778,
+    description: "OpenClaw diagnostics and agent dashboard",
+    icon: "activity",
+    color: "amber",
+    subdomain: "clawdash",
+    openMaximized: true,
+    access: "private",
+    type: "nextjs",
   },
   {
     id: "os",


### PR DESCRIPTION
## What

ClawDash was missing from `apps-registry.ts` so it had no desktop icon in the OS.

## Changes
- Added `clawdash` entry (port 7778, amber color, activity icon)
- Added `activity` SVG icon to `registry-config.tsx`
- Added `amber` color to `COLOR_MAP`
- Added `standalone` to the `type` union (needed for Paperclip)

## Result
ClawDash now shows as a desktop icon in the OS alongside all other apps.