### PR TITLE
feat(clawdash): agent UI component library — avatars, chat, status cards

### DIFF
--- a/apps/clawdash/src/app/page.tsx
+++ b/apps/clawdash/src/app/page.tsx
@@ -14,6 +14,7 @@ import {
   DollarSign,
   Clock,
 } from "lucide-react";
+import { AgentStatusSection } from "@/components/agents/AgentStatusSection";
 
 function StatCard({
   label,
@@ -162,6 +163,8 @@ export default function OverviewPage() {
           OpenClaw agent diagnostics at a glance
         </p>
       </div>
+
+      <AgentStatusSection />
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <StatCard

--- a/apps/clawdash/src/components/agents/AgentAvatar.tsx
+++ b/apps/clawdash/src/components/agents/AgentAvatar.tsx
@@ -1,0 +1,108 @@
+import { cn } from "@/lib/utils";
+
+export type AgentId = "ash" | "ocean" | "skylar" | "coral" | "arctic";
+
+export interface AgentConfig {
+  id: AgentId;
+  name: string;
+  emoji: string;
+  role: string;
+  gradient: string;
+  glowColor: string;
+  ringColor: string;
+}
+
+export const AGENTS: Record<AgentId, AgentConfig> = {
+  ash: {
+    id: "ash",
+    name: "Ash",
+    emoji: "🔥",
+    role: "Head of Operations",
+    gradient: "from-orange-500 to-red-600",
+    glowColor: "rgba(249,115,22,0.35)",
+    ringColor: "ring-orange-500/30",
+  },
+  ocean: {
+    id: "ocean",
+    name: "Ocean",
+    emoji: "🌊",
+    role: "Head of Engineering",
+    gradient: "from-cyan-500 to-blue-600",
+    glowColor: "rgba(6,182,212,0.35)",
+    ringColor: "ring-cyan-500/30",
+  },
+  skylar: {
+    id: "skylar",
+    name: "Skylar",
+    emoji: "⚡",
+    role: "Head of Growth",
+    gradient: "from-yellow-400 to-amber-500",
+    glowColor: "rgba(234,179,8,0.35)",
+    ringColor: "ring-yellow-400/30",
+  },
+  coral: {
+    id: "coral",
+    name: "Coral",
+    emoji: "🪸",
+    role: "Head of Design",
+    gradient: "from-pink-500 to-rose-600",
+    glowColor: "rgba(236,72,153,0.35)",
+    ringColor: "ring-pink-500/30",
+  },
+  arctic: {
+    id: "arctic",
+    name: "Arctic",
+    emoji: "🧊",
+    role: "Head of Research",
+    gradient: "from-blue-400 to-slate-500",
+    glowColor: "rgba(96,165,250,0.35)",
+    ringColor: "ring-blue-400/30",
+  },
+};
+
+export type AvatarSize = "sm" | "md" | "lg" | "xl";
+
+const SIZE_CLASSES: Record<AvatarSize, { wrapper: string; emoji: string }> = {
+  sm: { wrapper: "w-8 h-8 rounded-lg text-base", emoji: "text-sm" },
+  md: { wrapper: "w-10 h-10 rounded-xl text-lg", emoji: "text-base" },
+  lg: { wrapper: "w-14 h-14 rounded-2xl text-2xl", emoji: "text-xl" },
+  xl: { wrapper: "w-20 h-20 rounded-3xl text-4xl", emoji: "text-3xl" },
+};
+
+interface AgentAvatarProps {
+  agent: AgentId | AgentConfig;
+  size?: AvatarSize;
+  showGlow?: boolean;
+  className?: string;
+}
+
+export function AgentAvatar({
+  agent,
+  size = "md",
+  showGlow = false,
+  className,
+}: AgentAvatarProps) {
+  const config = typeof agent === "string" ? AGENTS[agent] : agent;
+  const sizes = SIZE_CLASSES[size];
+
+  return (
+    <div
+      className={cn(
+        "relative flex items-center justify-center bg-gradient-to-br shrink-0 ring-1",
+        sizes.wrapper,
+        config.gradient,
+        config.ringColor,
+        className
+      )}
+      style={
+        showGlow
+          ? { boxShadow: `0 0 16px 2px ${config.glowColor}` }
+          : undefined
+      }
+    >
+      <span className={cn("leading-none select-none", sizes.emoji)}>
+        {config.emoji}
+      </span>
+    </div>
+  );
+}

--- a/apps/clawdash/src/components/agents/AgentCard.tsx
+++ b/apps/clawdash/src/components/agents/AgentCard.tsx
@@ -1,0 +1,84 @@
+import { cn } from "@/lib/utils";
+import { AgentAvatar, type AgentId, type AgentConfig, AGENTS } from "./AgentAvatar";
+import { AgentStatusBadge, type AgentStatus } from "./AgentStatusBadge";
+
+interface AgentCardProps {
+  agent: AgentId | AgentConfig;
+  status?: AgentStatus;
+  lastActive?: string;
+  taskSummary?: string;
+  onClick?: () => void;
+  className?: string;
+}
+
+export function AgentCard({
+  agent,
+  status = "idle",
+  lastActive,
+  taskSummary,
+  onClick,
+  className,
+}: AgentCardProps) {
+  const config = typeof agent === "string" ? AGENTS[agent] : agent;
+
+  return (
+    <div
+      onClick={onClick}
+      className={cn(
+        "group relative rounded-xl border border-border bg-card p-4",
+        "flex flex-col gap-3 min-w-[180px] select-none",
+        "transition-all duration-200",
+        onClick &&
+          "cursor-pointer hover:border-border/80 hover:bg-card/80 active:scale-[0.98]",
+        // Subtle top glow on hover matching agent color
+        onClick && "hover:shadow-sm",
+        className
+      )}
+    >
+      {/* Gradient top accent line */}
+      <div
+        className={cn(
+          "absolute top-0 left-4 right-4 h-px rounded-full bg-gradient-to-r opacity-0 group-hover:opacity-60 transition-opacity duration-300",
+          config.gradient
+        )}
+      />
+
+      {/* Avatar + status row */}
+      <div className="flex items-start justify-between gap-2">
+        <AgentAvatar
+          agent={config}
+          size="lg"
+          showGlow={status === "active" || status === "running"}
+        />
+        <AgentStatusBadge status={status} />
+      </div>
+
+      {/* Name + role */}
+      <div className="space-y-0.5">
+        <p className="text-[14px] font-semibold tracking-tight leading-none">
+          {config.name}
+        </p>
+        <p className="text-[11px] text-muted-foreground leading-tight">
+          {config.role}
+        </p>
+      </div>
+
+      {/* Task or last active */}
+      <div className="mt-auto">
+        {taskSummary ? (
+          <p className="text-[11px] text-muted-foreground line-clamp-2 leading-snug">
+            {taskSummary}
+          </p>
+        ) : lastActive ? (
+          <p className="text-[11px] text-muted-foreground/60">
+            Last active {lastActive}
+          </p>
+        ) : (
+          <p className="text-[11px] text-muted-foreground/40 italic">
+            No recent activity
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/clawdash/src/components/agents/AgentStatusBadge.tsx
+++ b/apps/clawdash/src/components/agents/AgentStatusBadge.tsx
@@ -1,0 +1,73 @@
+import { cn } from "@/lib/utils";
+
+export type AgentStatus = "active" | "idle" | "running";
+
+interface AgentStatusBadgeProps {
+  status: AgentStatus;
+  className?: string;
+}
+
+const STATUS_CONFIG: Record<
+  AgentStatus,
+  { label: string; dotClass: string; pillClass: string }
+> = {
+  active: {
+    label: "Active",
+    dotClass: "bg-emerald-500",
+    pillClass:
+      "bg-emerald-500/10 text-emerald-400 ring-1 ring-emerald-500/20",
+  },
+  idle: {
+    label: "Idle",
+    dotClass: "bg-muted-foreground/40",
+    pillClass:
+      "bg-muted/60 text-muted-foreground ring-1 ring-border",
+  },
+  running: {
+    label: "Running",
+    dotClass: "bg-blue-500",
+    pillClass:
+      "bg-blue-500/10 text-blue-400 ring-1 ring-blue-500/20",
+  },
+};
+
+export function AgentStatusBadge({ status, className }: AgentStatusBadgeProps) {
+  const config = STATUS_CONFIG[status];
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-medium",
+        config.pillClass,
+        className
+      )}
+    >
+      {/* Dot with animation */}
+      <span className="relative flex h-1.5 w-1.5 shrink-0">
+        {status === "active" && (
+          <span
+            className={cn(
+              "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",
+              config.dotClass
+            )}
+          />
+        )}
+        {status === "running" && (
+          <span
+            className={cn(
+              "animate-pulse absolute inline-flex h-full w-full rounded-full opacity-75",
+              config.dotClass
+            )}
+          />
+        )}
+        <span
+          className={cn(
+            "relative inline-flex rounded-full h-1.5 w-1.5",
+            config.dotClass
+          )}
+        />
+      </span>
+      {config.label}
+    </span>
+  );
+}

--- a/apps/clawdash/src/components/agents/AgentStatusSection.tsx
+++ b/apps/clawdash/src/components/agents/AgentStatusSection.tsx
@@ -1,0 +1,68 @@
+import { cn } from "@/lib/utils";
+import { AgentCard } from "./AgentCard";
+import { type AgentId } from "./AgentAvatar";
+import { type AgentStatus } from "./AgentStatusBadge";
+
+export interface AgentStatusData {
+  id: AgentId;
+  status: AgentStatus;
+  lastActive?: string;
+  taskSummary?: string;
+}
+
+interface AgentStatusSectionProps {
+  agents?: AgentStatusData[];
+  onAgentClick?: (agentId: AgentId) => void;
+  className?: string;
+}
+
+// Default static data — Ocean's API will replace this
+const DEFAULT_AGENTS: AgentStatusData[] = [
+  { id: "ash", status: "active", taskSummary: "Coordinating agent tasks and reviewing PRs" },
+  { id: "ocean", status: "running", taskSummary: "Building agent control plane API" },
+  { id: "skylar", status: "idle", lastActive: "2h ago" },
+  { id: "coral", status: "running", taskSummary: "Designing ClawDash agent UI components" },
+  { id: "arctic", status: "idle", lastActive: "5h ago" },
+];
+
+export function AgentStatusSection({
+  agents = DEFAULT_AGENTS,
+  onAgentClick,
+  className,
+}: AgentStatusSectionProps) {
+  return (
+    <div className={cn("space-y-3", className)}>
+      {/* Section header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-[13px] font-semibold tracking-tight">Agents</h2>
+          <p className="text-[11px] text-muted-foreground mt-0.5">
+            Blueprint OS team — {agents.filter((a) => a.status !== "idle").length} active
+          </p>
+        </div>
+      </div>
+
+      {/* Horizontal scrollable row */}
+      <div
+        className={cn(
+          "flex gap-3 overflow-x-auto pb-1",
+          "-mx-1 px-1", // slight negative margin for edge glow visibility
+          // Hide scrollbar but keep scroll functionality
+          "[&::-webkit-scrollbar]:h-0"
+        )}
+      >
+        {agents.map((agent) => (
+          <AgentCard
+            key={agent.id}
+            agent={agent.id}
+            status={agent.status}
+            lastActive={agent.lastActive}
+            taskSummary={agent.taskSummary}
+            onClick={onAgentClick ? () => onAgentClick(agent.id) : undefined}
+            className="shrink-0 w-[200px]"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/clawdash/src/components/agents/ChatInput.tsx
+++ b/apps/clawdash/src/components/agents/ChatInput.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useRef, type KeyboardEvent } from "react";
+import { cn } from "@/lib/utils";
+import { Send, Loader2 } from "lucide-react";
+
+const MAX_CHARS = 4000;
+
+interface ChatInputProps {
+  onSend: (message: string) => void;
+  isLoading?: boolean;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function ChatInput({
+  onSend,
+  isLoading = false,
+  placeholder = "Message the agent…",
+  disabled = false,
+  className,
+}: ChatInputProps) {
+  const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const charCount = value.length;
+  const isOverLimit = charCount > MAX_CHARS;
+  const canSend = value.trim().length > 0 && !isLoading && !disabled && !isOverLimit;
+
+  function handleSend() {
+    if (!canSend) return;
+    onSend(value.trim());
+    setValue("");
+    // Reset textarea height
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  function handleInput() {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+  }
+
+  return (
+    <div
+      className={cn(
+        "relative rounded-xl border border-border bg-card/80 backdrop-blur-sm",
+        "focus-within:border-border/80 focus-within:ring-2 focus-within:ring-ring/20",
+        "transition-all duration-150",
+        disabled && "opacity-50 pointer-events-none",
+        className
+      )}
+    >
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onInput={handleInput}
+        placeholder={placeholder}
+        disabled={disabled || isLoading}
+        rows={1}
+        className={cn(
+          "w-full resize-none bg-transparent px-4 pt-3 pb-10 text-[13px] leading-relaxed",
+          "text-foreground placeholder:text-muted-foreground/50",
+          "focus:outline-none",
+          "max-h-[200px] overflow-y-auto"
+        )}
+      />
+
+      {/* Bottom bar: char count + send */}
+      <div className="absolute bottom-2.5 left-4 right-2.5 flex items-center justify-between pointer-events-none">
+        {/* Character count */}
+        <span
+          className={cn(
+            "text-[10px] font-mono transition-colors",
+            charCount === 0
+              ? "text-transparent"
+              : isOverLimit
+                ? "text-destructive"
+                : charCount > MAX_CHARS * 0.8
+                  ? "text-warning"
+                  : "text-muted-foreground/50"
+          )}
+        >
+          {charCount}/{MAX_CHARS}
+        </span>
+
+        {/* Send button */}
+        <button
+          onClick={handleSend}
+          disabled={!canSend}
+          className={cn(
+            "pointer-events-auto flex items-center justify-center",
+            "w-7 h-7 rounded-lg transition-all duration-150",
+            canSend
+              ? "bg-primary text-primary-foreground hover:opacity-90 active:scale-95"
+              : "bg-muted text-muted-foreground/40 cursor-not-allowed"
+          )}
+        >
+          {isLoading ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <Send className="w-3.5 h-3.5" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/clawdash/src/components/agents/ChatMessage.tsx
+++ b/apps/clawdash/src/components/agents/ChatMessage.tsx
@@ -1,0 +1,94 @@
+import { cn } from "@/lib/utils";
+import { AgentAvatar, type AgentId, AGENTS } from "./AgentAvatar";
+
+export type MessageRole = "user" | "agent";
+
+export interface ChatMessageData {
+  id: string;
+  role: MessageRole;
+  content: string;
+  timestamp: Date | string;
+  agentId?: AgentId;
+  modelBadge?: string;
+}
+
+interface ChatMessageProps {
+  message: ChatMessageData;
+  className?: string;
+}
+
+function formatTime(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export function ChatMessage({ message, className }: ChatMessageProps) {
+  const isUser = message.role === "user";
+  const agentConfig = message.agentId ? AGENTS[message.agentId] : null;
+
+  return (
+    <div
+      className={cn(
+        "flex gap-2.5 px-4",
+        isUser ? "flex-row-reverse" : "flex-row",
+        className
+      )}
+    >
+      {/* Avatar */}
+      {!isUser && agentConfig ? (
+        <AgentAvatar agent={agentConfig} size="sm" className="mt-0.5 shrink-0" />
+      ) : !isUser ? (
+        // Fallback avatar for unknown agent
+        <div className="w-8 h-8 rounded-lg bg-muted flex items-center justify-center text-sm shrink-0 mt-0.5">
+          🤖
+        </div>
+      ) : (
+        // User avatar
+        <div className="w-8 h-8 rounded-lg bg-primary/20 ring-1 ring-primary/30 flex items-center justify-center text-xs font-semibold text-primary shrink-0 mt-0.5">
+          U
+        </div>
+      )}
+
+      {/* Bubble */}
+      <div
+        className={cn(
+          "flex flex-col gap-1 max-w-[75%]",
+          isUser ? "items-end" : "items-start"
+        )}
+      >
+        {/* Model badge / agent name row */}
+        {!isUser && (
+          <div className="flex items-center gap-2">
+            {agentConfig && (
+              <span className="text-[11px] font-medium text-foreground/70">
+                {agentConfig.name}
+              </span>
+            )}
+            {message.modelBadge && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground font-mono">
+                {message.modelBadge}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Message bubble */}
+        <div
+          className={cn(
+            "rounded-2xl px-3.5 py-2.5 text-[13px] leading-relaxed",
+            isUser
+              ? "bg-primary text-primary-foreground rounded-tr-sm"
+              : "bg-muted text-foreground rounded-tl-sm"
+          )}
+        >
+          <p className="whitespace-pre-wrap break-words">{message.content}</p>
+        </div>
+
+        {/* Timestamp */}
+        <span className="text-[10px] text-muted-foreground/60 px-1">
+          {formatTime(message.timestamp)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/clawdash/src/components/agents/ChatThread.tsx
+++ b/apps/clawdash/src/components/agents/ChatThread.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { ChatMessage, type ChatMessageData } from "./ChatMessage";
+
+interface ChatThreadProps {
+  messages: ChatMessageData[];
+  isLoading?: boolean;
+  emptyState?: React.ReactNode;
+  className?: string;
+}
+
+function TypingIndicator() {
+  return (
+    <div className="flex gap-2.5 px-4">
+      <div className="w-8 h-8 rounded-lg bg-muted flex items-center justify-center text-sm shrink-0 mt-0.5">
+        🤖
+      </div>
+      <div className="flex items-center gap-1.5 rounded-2xl rounded-tl-sm bg-muted px-3.5 py-3 h-9">
+        <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:0ms]" />
+        <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:150ms]" />
+        <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:300ms]" />
+      </div>
+    </div>
+  );
+}
+
+export function ChatThread({
+  messages,
+  isLoading = false,
+  emptyState,
+  className,
+}: ChatThreadProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to bottom when messages change or loading state changes
+  useEffect(() => {
+    const bottom = bottomRef.current;
+    if (!bottom) return;
+    bottom.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length, isLoading]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "flex flex-col gap-4 overflow-y-auto py-4",
+        "scrollbar-thin",
+        className
+      )}
+    >
+      {messages.length === 0 && !isLoading ? (
+        <div className="flex-1 flex items-center justify-center py-16">
+          {emptyState ?? (
+            <div className="text-center space-y-2">
+              <p className="text-[28px]">💬</p>
+              <p className="text-[13px] text-muted-foreground">
+                No messages yet. Start a conversation.
+              </p>
+            </div>
+          )}
+        </div>
+      ) : (
+        <>
+          {messages.map((message, index) => {
+            const prevMessage = index > 0 ? messages[index - 1] : null;
+            const isGrouped =
+              prevMessage?.role === message.role &&
+              prevMessage?.agentId === message.agentId;
+
+            return (
+              <div
+                key={message.id}
+                className={cn(isGrouped && "-mt-2")}
+              >
+                <ChatMessage message={message} />
+              </div>
+            );
+          })}
+
+          {isLoading && <TypingIndicator />}
+        </>
+      )}
+
+      {/* Scroll anchor */}
+      <div ref={bottomRef} className="h-0 shrink-0" />
+    </div>
+  );
+}

--- a/apps/clawdash/src/components/agents/index.ts
+++ b/apps/clawdash/src/components/agents/index.ts
@@ -1,0 +1,17 @@
+export { AgentAvatar, AGENTS } from "./AgentAvatar";
+export type { AgentId, AgentConfig, AvatarSize } from "./AgentAvatar";
+
+export { AgentStatusBadge } from "./AgentStatusBadge";
+export type { AgentStatus } from "./AgentStatusBadge";
+
+export { AgentCard } from "./AgentCard";
+
+export { ChatMessage } from "./ChatMessage";
+export type { ChatMessageData, MessageRole } from "./ChatMessage";
+
+export { ChatInput } from "./ChatInput";
+
+export { ChatThread } from "./ChatThread";
+
+export { AgentStatusSection } from "./AgentStatusSection";
+export type { AgentStatusData } from "./AgentStatusSection";


### PR DESCRIPTION
## 🪸 Agent UI Component Library

Designed by Coral — the visual system for Ocean's agent control plane.

### What's included

**Agent Avatar System** (`components/agents/`)
- `AgentAvatar.tsx` — Gradient avatars per agent: Ash🔥 red/orange, Ocean🌊 cyan/blue, Skylar⚡ yellow/amber, Coral🪸 pink/rose, Arctic🧊 blue/slate. Sizes sm/md/lg/xl with optional glow.
- `AgentStatusBadge.tsx` — Animated pill: Active (green ping), Running (blue pulse), Idle (gray)
- `AgentCard.tsx` — Card with avatar, name, role, status, task summary, hover accent

**Chat UI Components**
- `ChatMessage.tsx` — Bubbles with user/agent styling, timestamps, model badge, grouped messages
- `ChatInput.tsx` — Auto-resize textarea, send button, loading state, 4000-char counter, Shift+Enter for newline
- `ChatThread.tsx` — Scrollable list, auto-scroll to bottom, typing indicator (3-dot bounce)

**Dashboard Integration**
- `AgentStatusSection.tsx` — Horizontal scrollable row of all 5 agents at a glance
- Wired into `page.tsx` above stats grid

### Design principles
- ✅ Dark-first (matches existing ClawDash theme)
- ✅ macOS aesthetic — spatial, glass-friendly
- ✅ shadcn/ui + Tailwind only, no new dependencies
- ✅ TypeScript clean (`tsc --noEmit` passes)
- ✅ Consistent with existing component patterns

### For Ocean 🌊
All components are in `components/agents/` with a clean `index.ts` barrel export. Import what you need:
```ts
import { AgentAvatar, AgentCard, ChatThread, ChatInput, AgentStatusSection } from "@/components/agents";
```
The `AgentStatusSection` accepts live `AgentStatusData[]` — hook up your API and it'll render dynamically.