### PR TITLE
feat(clawdash): agent control plane — chat, session history, status cards

### DIFF
--- a/apps/clawdash/src/app/agents/page.tsx
+++ b/apps/clawdash/src/app/agents/page.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useSessions } from "@/hooks/use-sessions";
+import { useAgentStatuses, useSendMessage } from "@/hooks/use-agents";
+import type { AgentStatus } from "@/hooks/use-agents";
+import { timeAgo } from "@/lib/utils";
+import { Send, MessageSquare, ChevronRight } from "lucide-react";
+
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+}
+
+function AgentCard({
+  agent,
+  isSelected,
+  onSelect,
+}: {
+  agent: AgentStatus;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const statusColor =
+    agent.status === "active"
+      ? "bg-green-500"
+      : agent.status === "idle"
+        ? "bg-yellow-500"
+        : "bg-muted-foreground/30";
+
+  const statusLabel =
+    agent.status === "active"
+      ? "Active"
+      : agent.status === "idle"
+        ? "Idle"
+        : "Offline";
+
+  return (
+    <button
+      onClick={onSelect}
+      className={`w-full text-left px-3 py-2.5 rounded-lg transition-colors flex items-center gap-3 ${
+        isSelected
+          ? "bg-sidebar-primary text-sidebar-primary-foreground"
+          : "hover:bg-sidebar-accent text-sidebar-foreground/80 hover:text-sidebar-accent-foreground"
+      }`}
+    >
+      <span className="text-xl shrink-0">{agent.emoji}</span>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[13px] font-medium">{agent.name}</span>
+          <div
+            className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusColor} ${
+              agent.status === "active" ? "animate-pulse" : ""
+            }`}
+          />
+        </div>
+        <p className="text-[11px] text-current opacity-60 truncate">
+          {statusLabel}
+          {agent.lastSeen ? ` · ${timeAgo(agent.lastSeen)}` : ""}
+        </p>
+      </div>
+      <ChevronRight className="w-3.5 h-3.5 opacity-40 shrink-0" />
+    </button>
+  );
+}
+
+function ChatPanel({ agent }: { agent: AgentStatus }) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const { mutate: sendMessage, isPending } = useSendMessage();
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  function handleSend() {
+    const text = input.trim();
+    if (!text || isPending) return;
+
+    const userMsg: ChatMessage = {
+      id: String(Date.now()),
+      role: "user",
+      content: text,
+      timestamp: new Date().toISOString(),
+    };
+
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
+
+    sendMessage(
+      {
+        message: text,
+        agentId: agent.id,
+        sessionKey: agent.sessionKey,
+      },
+      {
+        onSuccess: (data) => {
+          const responseText =
+            typeof data.response === "string"
+              ? data.response
+              : data.error
+                ? `Error: ${data.error}`
+                : JSON.stringify(data, null, 2);
+
+          const assistantMsg: ChatMessage = {
+            id: String(Date.now() + 1),
+            role: "assistant",
+            content: responseText,
+            timestamp: new Date().toISOString(),
+          };
+          setMessages((prev) => [...prev, assistantMsg]);
+        },
+        onError: (err) => {
+          const errorMsg: ChatMessage = {
+            id: String(Date.now() + 1),
+            role: "assistant",
+            content: `Failed to send message: ${err.message}`,
+            timestamp: new Date().toISOString(),
+          };
+          setMessages((prev) => [...prev, errorMsg]);
+        },
+      }
+    );
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="px-5 py-3.5 border-b border-border flex items-center gap-3 shrink-0">
+        <span className="text-2xl">{agent.emoji}</span>
+        <div>
+          <h2 className="text-[14px] font-semibold">{agent.name}</h2>
+          <p className="text-[12px] text-muted-foreground">
+            {agent.model ?? "No active session"}
+            {agent.messageCount !== undefined
+              ? ` · ${agent.messageCount} messages`
+              : ""}
+          </p>
+        </div>
+        <div className="ml-auto flex items-center gap-1.5">
+          <div
+            className={`w-1.5 h-1.5 rounded-full ${
+              agent.status === "active"
+                ? "bg-green-500 animate-pulse"
+                : agent.status === "idle"
+                  ? "bg-yellow-500"
+                  : "bg-muted-foreground/30"
+            }`}
+          />
+          <span className="text-[12px] text-muted-foreground capitalize">
+            {agent.status}
+          </span>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {messages.length === 0 ? (
+          <div className="h-full flex flex-col items-center justify-center text-center gap-3">
+            <MessageSquare className="w-10 h-10 text-muted-foreground/30" />
+            <div>
+              <p className="text-[14px] font-medium text-muted-foreground">
+                No messages yet
+              </p>
+              <p className="text-[12px] text-muted-foreground mt-1">
+                Send a message to {agent.name} to start a conversation
+              </p>
+            </div>
+          </div>
+        ) : (
+          messages.map((msg) => (
+            <div
+              key={msg.id}
+              className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+            >
+              <div
+                className={`max-w-[80%] rounded-xl px-3.5 py-2.5 text-[13px] leading-relaxed ${
+                  msg.role === "user"
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-foreground"
+                }`}
+              >
+                <p className="whitespace-pre-wrap break-words">{msg.content}</p>
+                <p
+                  className={`text-[10px] mt-1 ${
+                    msg.role === "user"
+                      ? "text-primary-foreground/60 text-right"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  {timeAgo(msg.timestamp)}
+                </p>
+              </div>
+            </div>
+          ))
+        )}
+        {isPending && (
+          <div className="flex justify-start">
+            <div className="bg-muted rounded-xl px-3.5 py-2.5">
+              <div className="flex gap-1 items-center h-4">
+                <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:0ms]" />
+                <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:150ms]" />
+                <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:300ms]" />
+              </div>
+            </div>
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input */}
+      <div className="px-4 py-3 border-t border-border shrink-0">
+        <div className="flex items-end gap-2">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={`Message ${agent.name}…`}
+            rows={1}
+            className="flex-1 bg-input rounded-xl px-3.5 py-2.5 text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 resize-none min-h-[40px] max-h-[120px]"
+            style={{ fieldSizing: "content" } as React.CSSProperties}
+          />
+          <button
+            onClick={handleSend}
+            disabled={!input.trim() || isPending}
+            className="w-9 h-9 rounded-xl bg-primary text-primary-foreground flex items-center justify-center shrink-0 disabled:opacity-40 hover:bg-primary/90 transition-colors"
+          >
+            <Send className="w-4 h-4" />
+          </button>
+        </div>
+        <p className="text-[11px] text-muted-foreground mt-1.5 px-1">
+          Press Enter to send · Shift+Enter for new line
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function AgentsPage() {
+  const { data: sessionsData } = useSessions();
+  const sessions = sessionsData?.sessions ?? [];
+  const agents = useAgentStatuses(sessions);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+
+  const selectedAgent = agents.find((a) => a.id === selectedAgentId) ?? null;
+
+  return (
+    <div className="h-full flex">
+      {/* Agent list sidebar */}
+      <div className="w-56 shrink-0 border-r border-border flex flex-col">
+        <div className="px-4 py-3.5 border-b border-border">
+          <h1 className="text-[14px] font-semibold tracking-tight">Agents</h1>
+          <p className="text-[11px] text-muted-foreground mt-0.5">
+            Chat with active agents
+          </p>
+        </div>
+        <div className="flex-1 overflow-y-auto px-2 py-2 space-y-0.5">
+          {agents.map((agent) => (
+            <AgentCard
+              key={agent.id}
+              agent={agent}
+              isSelected={selectedAgentId === agent.id}
+              onSelect={() => setSelectedAgentId(agent.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Chat area */}
+      <div className="flex-1 min-w-0">
+        {selectedAgent ? (
+          <ChatPanel agent={selectedAgent} />
+        ) : (
+          <div className="h-full flex flex-col items-center justify-center text-center gap-4 p-8">
+            <div className="flex gap-1">
+              {agents.slice(0, 3).map((a) => (
+                <span key={a.id} className="text-3xl">
+                  {a.emoji}
+                </span>
+              ))}
+            </div>
+            <div>
+              <p className="text-[15px] font-semibold">Select an agent</p>
+              <p className="text-[13px] text-muted-foreground mt-1">
+                Choose an agent from the list to start chatting
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/clawdash/src/app/api/agents/route.ts
+++ b/apps/clawdash/src/app/api/agents/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const KNOWN_AGENTS = [
+  { id: "main", name: "Ash", emoji: "🔥" },
+  { id: "ocean", name: "Ocean", emoji: "🌊" },
+  { id: "skylar", name: "Skylar", emoji: "⚡" },
+  { id: "coral", name: "Coral", emoji: "🪸" },
+  { id: "arctic", name: "Arctic", emoji: "🧊" },
+];
+
+export async function GET() {
+  return NextResponse.json({ agents: KNOWN_AGENTS });
+}

--- a/apps/clawdash/src/app/api/message/route.ts
+++ b/apps/clawdash/src/app/api/message/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const SERVER_BASE =
+  process.env.OPENCLAW_SERVER_URL ?? "http://localhost:3001";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json() as { message: string; agentId?: string; sessionKey?: string };
+    const res = await fetch(`${SERVER_BASE}/api/openclaw/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json();
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+    return NextResponse.json(data);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to send message";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/apps/clawdash/src/app/api/session-messages/route.ts
+++ b/apps/clawdash/src/app/api/session-messages/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { getOpenClawDir, getAgentId } from "@/lib/openclaw";
+import { existsSync } from "fs";
+
+export const dynamic = "force-dynamic";
+
+interface JournalEntry {
+  type: string;
+  id?: string;
+  timestamp?: string;
+  message?: {
+    role?: string;
+    content?: string | Array<{ type: string; text?: string }>;
+    timestamp?: number;
+  };
+}
+
+export interface SessionMessage {
+  id: string;
+  role: "user" | "assistant" | "tool";
+  content: string;
+  timestamp: string;
+}
+
+function extractText(
+  content: string | Array<{ type: string; text?: string }>
+): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((c) => c.type === "text")
+      .map((c) => c.text ?? "")
+      .join("\n")
+      .trim();
+  }
+  return "";
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const sessionId = searchParams.get("sessionId");
+  const agentId = searchParams.get("agentId") ?? getAgentId();
+  const limit = Math.min(parseInt(searchParams.get("limit") ?? "50"), 200);
+
+  if (!sessionId) {
+    return NextResponse.json({ error: "sessionId required" }, { status: 400 });
+  }
+
+  const sessionsDir = join(getOpenClawDir(), "agents", agentId, "sessions");
+  const filePath = join(sessionsDir, `${sessionId}.jsonl`);
+
+  if (!existsSync(filePath)) {
+    return NextResponse.json({ messages: [] });
+  }
+
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const lines = raw.trim().split("\n").filter(Boolean);
+
+    const messages: SessionMessage[] = [];
+
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as JournalEntry;
+        if (entry.type !== "message" || !entry.message) continue;
+
+        const role = entry.message.role;
+        if (role !== "user" && role !== "assistant") continue;
+
+        const content = extractText(entry.message.content ?? "");
+        if (!content.trim()) continue;
+
+        messages.push({
+          id: entry.id ?? String(messages.length),
+          role: role as "user" | "assistant",
+          content,
+          timestamp:
+            entry.timestamp ??
+            (entry.message.timestamp
+              ? new Date(entry.message.timestamp).toISOString()
+              : new Date().toISOString()),
+        });
+      } catch {
+        // skip malformed lines
+      }
+    }
+
+    // Return last N messages
+    return NextResponse.json({ messages: messages.slice(-limit) });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to read session" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/clawdash/src/app/page.tsx
+++ b/apps/clawdash/src/app/page.tsx
@@ -3,7 +3,9 @@
 import { useSessions } from "@/hooks/use-sessions";
 import { useSystemHealth } from "@/hooks/use-system-health";
 import { useCosts } from "@/hooks/use-costs";
+import { useAgentStatuses } from "@/hooks/use-agents";
 import { formatBytes, formatNumber, formatCost } from "@/lib/utils";
+import { AgentStatusCards } from "@/components/agents/agent-status-cards";
 import {
   Activity,
   Cpu,
@@ -115,9 +117,9 @@ function SessionsPreview({
               <div
                 className={`w-1.5 h-1.5 rounded-full shrink-0 ${
                   s.status === "active"
-                    ? "bg-success animate-pulse"
+                    ? "bg-green-500 animate-pulse"
                     : s.status === "idle"
-                      ? "bg-warning"
+                      ? "bg-yellow-500"
                       : "bg-muted-foreground/30"
                 }`}
               />
@@ -148,6 +150,7 @@ export default function OverviewPage() {
   const { data: costsData } = useCosts();
 
   const sessions = sessionsData?.sessions || [];
+  const agentStatuses = useAgentStatuses(sessions);
   const activeSessions = sessions.filter((s) => s.status === "active").length;
   const totalTokens = sessions.reduce(
     (sum, s) => sum + s.tokensIn + s.tokensOut,
@@ -164,8 +167,7 @@ export default function OverviewPage() {
         </p>
       </div>
 
-      <AgentStatusSection />
-
+      <AgentStatusCards agents={agentStatuses} />
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <StatCard
           label="Active Sessions"

--- a/apps/clawdash/src/app/sessions/page.tsx
+++ b/apps/clawdash/src/app/sessions/page.tsx
@@ -2,13 +2,96 @@
 
 import { useState, useMemo } from "react";
 import { useSessions } from "@/hooks/use-sessions";
+import { useSessionMessages } from "@/hooks/use-session-messages";
 import { formatNumber, formatCost, timeAgo } from "@/lib/utils";
-import { Search, Filter } from "lucide-react";
+import { Search, X, MessageSquare, ChevronRight } from "lucide-react";
+
+function MessageViewer({
+  sessionId,
+  onClose,
+}: {
+  sessionId: string;
+  onClose: () => void;
+}) {
+  const { data, isLoading } = useSessionMessages(sessionId);
+  const messages = data?.messages ?? [];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50">
+      <div className="bg-card border border-border rounded-2xl w-full max-w-2xl max-h-[80vh] flex flex-col mx-4 sm:mx-0">
+        <div className="px-5 py-3.5 border-b border-border flex items-center justify-between shrink-0">
+          <div>
+            <h3 className="text-[14px] font-semibold">Session Messages</h3>
+            <p className="text-[11px] text-muted-foreground font-mono mt-0.5">
+              {sessionId.slice(0, 24)}…
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 rounded-lg hover:bg-accent flex items-center justify-center transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          {isLoading ? (
+            <div className="text-center py-8 text-[13px] text-muted-foreground">
+              Loading messages…
+            </div>
+          ) : messages.length === 0 ? (
+            <div className="text-center py-8 text-[13px] text-muted-foreground flex flex-col items-center gap-2">
+              <MessageSquare className="w-8 h-8 opacity-30" />
+              No messages found for this session.
+            </div>
+          ) : (
+            messages.map((msg) => (
+              <div
+                key={msg.id}
+                className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  className={`max-w-[85%] rounded-xl px-3.5 py-2.5 text-[13px] leading-relaxed ${
+                    msg.role === "user"
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-foreground"
+                  }`}
+                >
+                  <p className="whitespace-pre-wrap break-words line-clamp-10">
+                    {msg.content}
+                  </p>
+                  <p
+                    className={`text-[10px] mt-1 ${
+                      msg.role === "user"
+                        ? "text-primary-foreground/60 text-right"
+                        : "text-muted-foreground"
+                    }`}
+                  >
+                    {timeAgo(msg.timestamp)}
+                  </p>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="px-4 py-2.5 border-t border-border shrink-0">
+          <p className="text-[11px] text-muted-foreground">
+            Showing last {messages.length} messages
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function SessionsPage() {
   const { data } = useSessions();
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
+    null
+  );
 
   const sessions = data?.sessions || [];
 
@@ -34,7 +117,7 @@ export default function SessionsPage() {
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Sessions</h1>
         <p className="text-[13px] text-muted-foreground mt-1">
-          All agent sessions and their activity
+          All agent sessions and their activity — click a row to view messages
         </p>
       </div>
 
@@ -43,7 +126,7 @@ export default function SessionsPage() {
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <input
             type="text"
-            placeholder="Search sessions..."
+            placeholder="Search sessions…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="w-full h-9 pl-9 pr-3 rounded-full bg-input text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
@@ -67,7 +150,7 @@ export default function SessionsPage() {
       </div>
 
       <div className="rounded-xl border border-border bg-card overflow-hidden">
-        <div className="grid grid-cols-[1fr_1fr_100px_100px_100px_80px_100px] gap-2 px-4 py-2.5 border-b border-border text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
+        <div className="grid grid-cols-[1fr_1fr_100px_100px_100px_80px_100px_32px] gap-2 px-4 py-2.5 border-b border-border text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
           <span>Session</span>
           <span>Model</span>
           <span className="text-right">Tokens In</span>
@@ -75,6 +158,7 @@ export default function SessionsPage() {
           <span className="text-right">Messages</span>
           <span className="text-right">Cost</span>
           <span className="text-right">Updated</span>
+          <span />
         </div>
         {filtered.length === 0 ? (
           <div className="p-8 text-center text-[13px] text-muted-foreground">
@@ -87,15 +171,16 @@ export default function SessionsPage() {
             {filtered.map((s) => (
               <div
                 key={s.id}
-                className="grid grid-cols-[1fr_1fr_100px_100px_100px_80px_100px] gap-2 px-4 py-2.5 items-center hover:bg-accent/50 transition-colors"
+                onClick={() => setSelectedSessionId(s.id)}
+                className="grid grid-cols-[1fr_1fr_100px_100px_100px_80px_100px_32px] gap-2 px-4 py-2.5 items-center hover:bg-accent/50 transition-colors cursor-pointer"
               >
                 <div className="flex items-center gap-2 min-w-0">
                   <div
                     className={`w-1.5 h-1.5 rounded-full shrink-0 ${
                       s.status === "active"
-                        ? "bg-success"
+                        ? "bg-green-500 animate-pulse"
                         : s.status === "idle"
-                          ? "bg-warning"
+                          ? "bg-yellow-500"
                           : "bg-muted-foreground/30"
                     }`}
                   />
@@ -121,11 +206,19 @@ export default function SessionsPage() {
                 <span className="text-[12px] text-right text-muted-foreground">
                   {timeAgo(s.updatedAt)}
                 </span>
+                <ChevronRight className="w-3.5 h-3.5 text-muted-foreground/40 ml-auto" />
               </div>
             ))}
           </div>
         )}
       </div>
+
+      {selectedSessionId && (
+        <MessageViewer
+          sessionId={selectedSessionId}
+          onClose={() => setSelectedSessionId(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/clawdash/src/components/agents/agent-status-cards.tsx
+++ b/apps/clawdash/src/components/agents/agent-status-cards.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { AgentStatus } from "@/hooks/use-agents";
+import { useSendMessage } from "@/hooks/use-agents";
+import { timeAgo } from "@/lib/utils";
+import { Send, X, MessageSquare } from "lucide-react";
+
+interface QuickSendModalProps {
+  agent: AgentStatus;
+  onClose: () => void;
+}
+
+function QuickSendModal({ agent, onClose }: QuickSendModalProps) {
+  const [message, setMessage] = useState("");
+  const [sent, setSent] = useState(false);
+  const [response, setResponse] = useState<string | null>(null);
+  const { mutate: sendMessage, isPending } = useSendMessage();
+
+  function handleSend() {
+    const text = message.trim();
+    if (!text || isPending) return;
+
+    sendMessage(
+      {
+        message: text,
+        agentId: agent.id,
+        sessionKey: agent.sessionKey,
+      },
+      {
+        onSuccess: (data) => {
+          setSent(true);
+          if (typeof data.response === "string") {
+            setResponse(data.response);
+          } else if (data.error) {
+            setResponse(`Error: ${String(data.error)}`);
+          } else {
+            setResponse("Message sent.");
+          }
+        },
+        onError: (err) => {
+          setSent(true);
+          setResponse(`Failed: ${err.message}`);
+        },
+      }
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="bg-card border border-border rounded-2xl w-full max-w-md flex flex-col gap-0 overflow-hidden">
+        <div className="px-5 py-3.5 border-b border-border flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <span className="text-xl">{agent.emoji}</span>
+            <div>
+              <h3 className="text-[14px] font-semibold">
+                Quick message to {agent.name}
+              </h3>
+              <p className="text-[11px] text-muted-foreground capitalize">
+                {agent.status}
+                {agent.lastSeen ? ` · ${timeAgo(agent.lastSeen)}` : ""}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 rounded-lg hover:bg-accent flex items-center justify-center transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {sent && response ? (
+          <div className="p-5 space-y-3">
+            <p className="text-[12px] text-muted-foreground font-medium uppercase tracking-wider">
+              Response
+            </p>
+            <div className="bg-muted rounded-xl p-3.5 text-[13px] leading-relaxed max-h-48 overflow-y-auto whitespace-pre-wrap">
+              {response}
+            </div>
+            <button
+              onClick={onClose}
+              className="w-full h-9 rounded-xl bg-primary text-primary-foreground text-[13px] font-medium hover:bg-primary/90 transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        ) : (
+          <div className="p-5 space-y-3">
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSend();
+                }
+              }}
+              placeholder={`Message ${agent.name}…`}
+              rows={3}
+              autoFocus
+              className="w-full bg-input rounded-xl px-3.5 py-2.5 text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 resize-none"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={onClose}
+                className="flex-1 h-9 rounded-xl border border-border text-[13px] hover:bg-accent transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSend}
+                disabled={!message.trim() || isPending}
+                className="flex-1 h-9 rounded-xl bg-primary text-primary-foreground text-[13px] font-medium disabled:opacity-40 hover:bg-primary/90 transition-colors flex items-center justify-center gap-1.5"
+              >
+                {isPending ? (
+                  <span className="w-3.5 h-3.5 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full animate-spin" />
+                ) : (
+                  <Send className="w-3.5 h-3.5" />
+                )}
+                Send
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AgentCard({
+  agent,
+  onQuickSend,
+}: {
+  agent: AgentStatus;
+  onQuickSend: () => void;
+}) {
+  const router = useRouter();
+
+  const statusColor =
+    agent.status === "active"
+      ? "bg-green-500"
+      : agent.status === "idle"
+        ? "bg-yellow-500"
+        : "bg-muted-foreground/30";
+
+  const statusLabel =
+    agent.status === "active"
+      ? "Active"
+      : agent.status === "idle"
+        ? "Idle"
+        : "Offline";
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2.5">
+          <span className="text-2xl">{agent.emoji}</span>
+          <div>
+            <p className="text-[14px] font-semibold">{agent.name}</p>
+            <div className="flex items-center gap-1.5 mt-0.5">
+              <div
+                className={`w-1.5 h-1.5 rounded-full ${statusColor} ${
+                  agent.status === "active" ? "animate-pulse" : ""
+                }`}
+              />
+              <span className="text-[11px] text-muted-foreground">
+                {statusLabel}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-1 text-[12px] text-muted-foreground">
+        <div className="flex items-center justify-between">
+          <span>Last seen</span>
+          <span className="text-foreground/80">
+            {agent.lastSeen ? timeAgo(agent.lastSeen) : "Never"}
+          </span>
+        </div>
+        {agent.model && (
+          <div className="flex items-center justify-between">
+            <span>Model</span>
+            <span className="text-foreground/80 font-mono text-[11px] truncate max-w-[120px]">
+              {agent.model.split("/").pop() ?? agent.model}
+            </span>
+          </div>
+        )}
+        {agent.messageCount !== undefined && (
+          <div className="flex items-center justify-between">
+            <span>Messages</span>
+            <span className="text-foreground/80">{agent.messageCount}</span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-2 mt-auto pt-1">
+        <button
+          onClick={() => router.push(`/agents`)}
+          className="flex-1 h-8 rounded-lg border border-border text-[12px] hover:bg-accent transition-colors flex items-center justify-center gap-1.5"
+        >
+          <MessageSquare className="w-3.5 h-3.5" />
+          Chat
+        </button>
+        <button
+          onClick={onQuickSend}
+          className="flex-1 h-8 rounded-lg bg-primary/10 text-primary text-[12px] hover:bg-primary/20 transition-colors flex items-center justify-center gap-1.5"
+        >
+          <Send className="w-3.5 h-3.5" />
+          Quick Send
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function AgentStatusCards({ agents }: { agents: AgentStatus[] }) {
+  const [quickSendAgent, setQuickSendAgent] = useState<AgentStatus | null>(
+    null
+  );
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[13px] font-semibold">Agent Status</span>
+        <span className="text-[11px] text-muted-foreground">
+          {agents.filter((a) => a.status === "active").length} active
+        </span>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        {agents.map((agent) => (
+          <AgentCard
+            key={agent.id}
+            agent={agent}
+            onQuickSend={() => setQuickSendAgent(agent)}
+          />
+        ))}
+      </div>
+
+      {quickSendAgent && (
+        <QuickSendModal
+          agent={quickSendAgent}
+          onClose={() => setQuickSendAgent(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/clawdash/src/components/app-sidebar.tsx
+++ b/apps/clawdash/src/components/app-sidebar.tsx
@@ -14,9 +14,16 @@ import {
   ScrollText,
   Clock,
   Settings,
+  Bot,
 } from "lucide-react";
 
 const navSections = [
+  {
+    label: "Control",
+    items: [
+      { href: "/agents", label: "Agents", icon: Bot },
+    ],
+  },
   {
     label: "Monitor",
     items: [

--- a/apps/clawdash/src/hooks/use-agents.ts
+++ b/apps/clawdash/src/hooks/use-agents.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useQuery, useMutation } from "@tanstack/react-query";
+import type { SessionInfo } from "@/hooks/use-sessions";
+
+export interface AgentMeta {
+  id: string;
+  name: string;
+  emoji: string;
+}
+
+export interface AgentStatus extends AgentMeta {
+  status: "active" | "idle" | "offline";
+  lastSeen?: string;
+  sessionKey?: string;
+  model?: string;
+  messageCount?: number;
+}
+
+export function useAgents() {
+  return useQuery<{ agents: AgentMeta[] }>({
+    queryKey: ["agents"],
+    queryFn: async () => {
+      const res = await fetch("/api/agents");
+      return res.json();
+    },
+    staleTime: 60_000,
+  });
+}
+
+export function useAgentStatuses(sessions: SessionInfo[]) {
+  const KNOWN_AGENTS: AgentMeta[] = [
+    { id: "main", name: "Ash", emoji: "🔥" },
+    { id: "ocean", name: "Ocean", emoji: "🌊" },
+    { id: "skylar", name: "Skylar", emoji: "⚡" },
+    { id: "coral", name: "Coral", emoji: "🪸" },
+    { id: "arctic", name: "Arctic", emoji: "🧊" },
+  ];
+
+  return KNOWN_AGENTS.map((agent): AgentStatus => {
+    // Match sessions by agent id in the session key/channel
+    const agentSessions = sessions.filter(
+      (s) =>
+        s.channel?.toLowerCase().includes(agent.id) ||
+        s.id.toLowerCase().includes(agent.id)
+    );
+
+    const latestSession = agentSessions.sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    )[0];
+
+    if (!latestSession) {
+      return { ...agent, status: "offline" };
+    }
+
+    const lastSeenMs =
+      Date.now() - new Date(latestSession.updatedAt).getTime();
+    const isActive = latestSession.status === "active";
+    const isRecent = lastSeenMs < 5 * 60 * 1000; // 5 min
+
+    return {
+      ...agent,
+      status: isActive ? "active" : isRecent ? "idle" : "offline",
+      lastSeen: latestSession.updatedAt,
+      sessionKey: latestSession.id,
+      model: latestSession.model,
+      messageCount: latestSession.messageCount,
+    };
+  });
+}
+
+export interface SendMessagePayload {
+  message: string;
+  agentId?: string;
+  sessionKey?: string;
+}
+
+export interface SendMessageResponse {
+  ok?: boolean;
+  response?: string;
+  error?: string;
+  [key: string]: unknown;
+}
+
+export function useSendMessage() {
+  return useMutation<SendMessageResponse, Error, SendMessagePayload>({
+    mutationFn: async (payload) => {
+      const res = await fetch("/api/message", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      return res.json();
+    },
+  });
+}

--- a/apps/clawdash/src/hooks/use-session-messages.ts
+++ b/apps/clawdash/src/hooks/use-session-messages.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+export interface SessionMessage {
+  id: string;
+  role: "user" | "assistant" | "tool";
+  content: string;
+  timestamp: string;
+}
+
+export function useSessionMessages(
+  sessionId: string | null,
+  agentId?: string,
+  limit = 50
+) {
+  return useQuery<{ messages: SessionMessage[] }>({
+    queryKey: ["session-messages", sessionId, agentId, limit],
+    queryFn: async () => {
+      const params = new URLSearchParams({ sessionId: sessionId! });
+      if (agentId) params.set("agentId", agentId);
+      params.set("limit", String(limit));
+      const res = await fetch(`/api/session-messages?${params}`);
+      return res.json();
+    },
+    enabled: !!sessionId,
+    staleTime: 10_000,
+  });
+}

--- a/apps/clawdash/src/lib/openclaw.ts
+++ b/apps/clawdash/src/lib/openclaw.ts
@@ -44,6 +44,83 @@ export interface SessionInfo {
   channel?: string;
 }
 
+interface JournalEntry {
+  type: string;
+  id?: string;
+  version?: number;
+  timestamp?: string;
+  provider?: string;
+  modelId?: string;
+  customType?: string;
+  message?: {
+    role?: string;
+    content?: unknown;
+    timestamp?: number;
+  };
+}
+
+async function parseJsonlSession(
+  sessionId: string,
+  filePath: string,
+  fileStat: { mtimeMs: number }
+): Promise<SessionInfo | null> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const lines = raw.trim().split("\n").filter(Boolean);
+
+    let model = "unknown";
+    let createdAt: string | null = null;
+    let messageCount = 0;
+
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as JournalEntry;
+        if (entry.type === "session" && entry.timestamp) {
+          createdAt = entry.timestamp;
+        }
+        if (
+          (entry.type === "model_change" ||
+            entry.customType === "model-snapshot") &&
+          entry.modelId
+        ) {
+          model = `${entry.provider ?? "anthropic"}/${entry.modelId}`;
+        }
+        if (
+          entry.type === "message" &&
+          entry.message?.role === "user"
+        ) {
+          messageCount++;
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+
+    const updatedAt = new Date(fileStat.mtimeMs).toISOString();
+    const ageMs = Date.now() - fileStat.mtimeMs;
+    const status: SessionInfo["status"] =
+      ageMs < 2 * 60 * 1000
+        ? "active"
+        : ageMs < 30 * 60 * 1000
+          ? "idle"
+          : "closed";
+
+    return {
+      id: sessionId,
+      model,
+      status,
+      tokensIn: 0,
+      tokensOut: 0,
+      costCents: 0,
+      messageCount,
+      createdAt: createdAt ?? updatedAt,
+      updatedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export async function listSessions(): Promise<SessionInfo[]> {
   const sessionsDir = join(
     getOpenClawDir(),
@@ -57,25 +134,40 @@ export async function listSessions(): Promise<SessionInfo[]> {
   const sessions: SessionInfo[] = [];
 
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const metaPath = join(sessionsDir, entry.name, "metadata.json");
-    try {
-      const raw = await readFile(metaPath, "utf-8");
-      const meta = JSON.parse(raw);
-      sessions.push({
-        id: entry.name,
-        model: meta.model || "unknown",
-        status: meta.status || "idle",
-        tokensIn: meta.tokensIn || meta.inputTokens || 0,
-        tokensOut: meta.tokensOut || meta.outputTokens || 0,
-        costCents: meta.costCents || meta.cost || 0,
-        messageCount: meta.messageCount || meta.messages?.length || 0,
-        createdAt: meta.createdAt || meta.created || new Date().toISOString(),
-        updatedAt: meta.updatedAt || meta.updated || new Date().toISOString(),
-        channel: meta.channel,
-      });
-    } catch {
-      // skip unreadable sessions
+    // Support both JSONL files and subdirectory metadata.json
+    if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      const sessionId = entry.name.replace(/\.jsonl$/, "");
+      // Skip reset files
+      if (sessionId.includes(".reset.")) continue;
+      const filePath = join(sessionsDir, entry.name);
+      try {
+        const fileStat = await stat(filePath);
+        const session = await parseJsonlSession(sessionId, filePath, fileStat);
+        if (session) sessions.push(session);
+      } catch {
+        // skip
+      }
+    } else if (entry.isDirectory()) {
+      const metaPath = join(sessionsDir, entry.name, "metadata.json");
+      try {
+        const raw = await readFile(metaPath, "utf-8");
+        const meta = JSON.parse(raw);
+        sessions.push({
+          id: entry.name,
+          model: meta.model || "unknown",
+          status: meta.status || "idle",
+          tokensIn: meta.tokensIn || meta.inputTokens || 0,
+          tokensOut: meta.tokensOut || meta.outputTokens || 0,
+          costCents: meta.costCents || meta.cost || 0,
+          messageCount: meta.messageCount || meta.messages?.length || 0,
+          createdAt: meta.createdAt || meta.created || new Date().toISOString(),
+          updatedAt:
+            meta.updatedAt || meta.updated || new Date().toISOString(),
+          channel: meta.channel,
+        });
+      } catch {
+        // skip unreadable sessions
+      }
     }
   }
 


### PR DESCRIPTION
## What this does

Transforms ClawDash from a read-only telemetry dashboard into a real agent control plane.

### 1. Agent Chat Panel (`/agents`)
- New Agents nav section
- Lists Ash, Ocean, Skylar, Coral, Arctic with status/model info
- Click an agent → chat panel with message bubbles
- Messages sent via POST `/api/openclaw/message` proxy

### 2. Session History with Message Viewer
- Click any session row → modal with last 50 messages
- New `/api/session-messages` reads JSONL session files

### 3. Agent Status Cards on Overview
- 5 agent cards at top of dashboard
- Quick Send modal + Chat button on each card

### Technical
- Updated `listSessions()` to parse `.jsonl` files (OpenClaw v3)
- New hooks: `use-agents.ts`, `use-session-messages.ts`
- Build: clean ✅ TypeScript: no errors ✅