### PR TITLE
feat(storage): shared storage layer for agent-generated data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ storage/documents/*
 storage/temp/*
 !storage/**/.gitkeep
 
+# Runtime storage (agent-generated data, not committed)
+storage/skylar/
+
 # PM2
 ecosystem.config.cjs
 

--- a/apps/admin/src/app/api/skylar/brief/route.ts
+++ b/apps/admin/src/app/api/skylar/brief/route.ts
@@ -2,7 +2,9 @@ import { NextResponse } from "next/server";
 import fs from "fs";
 import path from "path";
 
-const BRIEF_PATH = "/home/deploy/.openclaw/workspace-skylar/industry-brief.md";
+const BRIEF_PATH = process.env.BLUEPRINT_STORAGE_PATH
+  ? `${process.env.BLUEPRINT_STORAGE_PATH}/skylar/industry-brief.md`
+  : "/home/deploy/repos/blueprint/storage/skylar/industry-brief.md";
 
 export async function GET() {
   try {

--- a/apps/admin/src/app/api/skylar/drafts/route.ts
+++ b/apps/admin/src/app/api/skylar/drafts/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import fs from "fs";
 import path from "path";
 
+// Drafts remain in Skylar's workspace since they are markdown files authored by Skylar,
+// not structured data shared with the server.
 const DRAFTS_DIR = "/home/deploy/.openclaw/workspace-skylar";
 
 interface Draft {

--- a/apps/admin/src/app/api/skylar/suggestions/route.ts
+++ b/apps/admin/src/app/api/skylar/suggestions/route.ts
@@ -3,8 +3,9 @@ import fs from "fs";
 
 import type { PostSuggestion } from "@/lib/types";
 
-const SUGGESTIONS_PATH =
-  "/home/deploy/.openclaw/workspace-skylar/post-suggestions.json";
+const SUGGESTIONS_PATH = process.env.BLUEPRINT_STORAGE_PATH
+  ? `${process.env.BLUEPRINT_STORAGE_PATH}/skylar/post-suggestions.json`
+  : "/home/deploy/repos/blueprint/storage/skylar/post-suggestions.json";
 
 // Batched format from Skylar's new suggestion generator
 interface BatchedPost {

--- a/storage/README.md
+++ b/storage/README.md
@@ -1,0 +1,25 @@
+# Blueprint OS — Shared Storage
+
+Runtime data files used by agents and the server. **Not committed to git.**
+
+## Structure
+
+- `skylar/post-suggestions.json` — Skylar's queued post suggestions
+- `skylar/growth-activity.json` — growth activity log (Reddit, X, etc.)
+- `skylar/industry-brief.md` — daily industry research brief (markdown)
+
+## Usage
+
+Server routes and agents read/write these files directly via the filesystem.
+The path can be overridden with the `BLUEPRINT_STORAGE_PATH` env var (defaults
+to `/home/deploy/repos/blueprint/storage`).
+
+## Setup
+
+On a fresh deployment, create the directories and seed empty data files:
+
+```bash
+mkdir -p storage/skylar
+echo '[]' > storage/skylar/post-suggestions.json
+echo '[]' > storage/skylar/growth-activity.json
+```


### PR DESCRIPTION
## Summary

Skylar was saving post suggestions and growth activity to her private workspace (`~/.openclaw/workspace-skylar/`). This meant the admin dashboard and other agents couldn't reliably access them.

## Changes

### New shared storage path
`/home/deploy/repos/blueprint/storage/skylar/` — accessible by all agents and the server.

### Files migrated
- `post-suggestions.json` — Skylar's queued post suggestions
- `growth-activity.json` — growth activity log (Reddit, X, etc.)
- `industry-brief.md` — daily industry research brief

### Routes updated
- `apps/admin/src/app/api/skylar/suggestions/route.ts`
- `apps/admin/src/app/api/skylar/brief/route.ts`

Both routes now use `BLUEPRINT_STORAGE_PATH` env var (with fallback to the new shared path).

### Other changes
- `storage/skylar/` added to `.gitignore` (runtime data, not committed)
- `storage/README.md` created — documents structure and setup
- Skylar's `TOOLS.md` updated with new paths

## Testing
- [x] Existing files copied to new location
- [x] Admin dashboard routes updated
- [x] Fallback defaults to `/home/deploy/repos/blueprint/storage/skylar/`