### PR TITLE
security: audit public repo exposure — remove sensitive data, update gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,12 @@ PRIVY_VERIFICATION_KEY=
 # Google Analytics (web app)
 # Get your Measurement ID from Google Analytics > Admin > Data Streams
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+
+# Server host (OS app — used to construct app URLs in the desktop environment)
+# For local development, leave empty (defaults to localhost)
+# For production, set to your server's hostname or IP
+NEXT_PUBLIC_APP_HOST=
+
+# Base domain for subdomain-based routing (optional)
+# If set, app URLs become https://<subdomain>.<BASE_DOMAIN>
+NEXT_PUBLIC_BASE_DOMAIN=

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,17 @@ storage/temp/*
 ecosystem.config.cjs
 
 apps/remotion/build.env.local
+
+# Sensitive data files — never commit
+storage/
+growth-activity.json
+post-suggestions.json
+*.secret
+
+# Paperclip local data (contains server IPs, auth config, runtime data)
+apps/paperclip/.paperclip/
+apps/paperclip/data/
+apps/paperclip/*.paperclip
+
+# Agent workspace files (should never be committed)
+workspace-*/

--- a/apps/os/.env.example
+++ b/apps/os/.env.example
@@ -1,0 +1,11 @@
+# Blueprint OS — Environment Variables
+
+# Public hostname or IP of your server (used to construct app URLs in the OS desktop)
+# Leave empty for local development (defaults to localhost)
+# Example: NEXT_PUBLIC_APP_HOST=your-server.example.com
+NEXT_PUBLIC_APP_HOST=
+
+# Base domain for subdomain-based routing (optional)
+# If set, app URLs become https://<subdomain>.<BASE_DOMAIN>
+# Example: NEXT_PUBLIC_BASE_DOMAIN=example.com
+NEXT_PUBLIC_BASE_DOMAIN=


### PR DESCRIPTION
## 🧊 Arctic — Security Audit: Public Repo Exposure

This PR is the result of a full security audit of the public GitHub repo for sensitive data.

---

## Changes Made

### `.gitignore` updates
- Add `apps/paperclip/.paperclip/` — contains server IP, auth config (was untracked but not explicitly ignored)
- Add `apps/paperclip/data/` — runtime agent data directory  
- Add `apps/paperclip/*.paperclip` — local paperclip files
- Add `storage/` — umbrella rule covering all agent-generated data directories
- Add `*.secret` — secret files should never be committed
- Add `workspace-*/` — agent workspace directories
- Add `growth-activity.json`, `post-suggestions.json` — Skylar agent data files

### `.env.example` (root)
- Document `NEXT_PUBLIC_APP_HOST` (OS app — used to set server hostname without hardcoding)
- Document `NEXT_PUBLIC_BASE_DOMAIN` (subdomain-based routing)

### `apps/os/.env.example` (new file)
- Was missing! Only `.env.local` existed (gitignored, contains real server IP)
- Documents what env vars are needed for the OS desktop app

---

## Audit Findings

### ✅ Source code — CLEAN
- All `.ts`/`.tsx`/`.js` files: **no hardcoded IPs found**
- `apps/os/src/app/page.tsx` uses `process.env.NEXT_PUBLIC_APP_HOST` ✅
- `apps/os/src/lib/registry-config.tsx` uses `process.env.NEXT_PUBLIC_APP_HOST` ✅
- `apps/clawdash/src/`: no hardcoded IPs or secrets ✅

### ⚠️ Git history
- **IP `54.151.66.76`** found in `AGENTS.md` on `ocean/paperclip-task-bridge` branch only
- **NOT in `allen/os` or `main`** — safe for now, but PR #28 should be updated
- No hardcoded IPs in any committed `.ts`/`.tsx`/`.js` source files

### ⚠️ Untracked files with sensitive data (now gitignored)
- `apps/paperclip/.paperclip/config.json` — contains `54.151.66.76` in `allowedHostnames` and `publicBaseUrl`
  - Was untracked but not explicitly gitignored → now explicitly covered
- `apps/os/.env.local` — contains `NEXT_PUBLIC_APP_HOST=54.151.66.76`
  - Already covered by `.env.*` rule ✅

### ✅ Build artifacts (already gitignored)
- `apps/os/.next/` build outputs contain IP (compiled from `.env.local`)
- Already covered by `.next/` ignore rule ✅

---

## Open PR Review

| PR | Title | Finding |
|---|---|---|
| #25 | feat: add Paperclip | ✅ Clean — `.paperclip/config.json` not committed |
| #26 | infra: paperclip PM2 + Caddy | ✅ Clean — no IPs or secrets |
| **#28** | docs: add Paperclip integration guide to AGENTS.md | ⚠️ Adds `54.151.66.76` to `AGENTS.md` — should use placeholder `<YOUR_SERVER_IP>:3100` |
| #29 | fix(admin): polish Marketing Dashboard | ℹ️ Minor — test file uses `worktree-shared-secret` (test string, not a real secret) |
| #30 | feat(clawdash): agent UI component library | ✅ Clean |
| #31 | feat(clawdash): agent control plane | ✅ Clean |
| #32 | feat(clawdash): mobile-first responsive layout | ✅ Clean |
| #33 | feat(admin): growth activity tracker | ✅ Clean |

---

## Action Items for Allen

1. **Merge this PR** to get gitignore and env.example updates in
2. **PR #28**: Before merging, replace `http://54.151.66.76:3100` with `http://<YOUR_SERVER_IP>:3100` in `AGENTS.md`
3. No real secrets were found in committed code — environment is well-protected

---

*Audited by Arctic 🧊 — Blueprint OS Infrastructure Engineer*