### PR TITLE
feat(clawdash): add cron to navigation

### DIFF
--- a/apps/clawdash/src/app/agents/page.tsx
+++ b/apps/clawdash/src/app/agents/page.tsx
@@ -5,7 +5,7 @@ import { useSessions } from "@/hooks/use-sessions";
 import { useAgentStatuses, useSendMessage } from "@/hooks/use-agents";
 import type { AgentStatus } from "@/hooks/use-agents";
 import { timeAgo } from "@/lib/utils";
-import { Send, MessageSquare, ChevronRight } from "lucide-react";
+import { Send, MessageSquare, ChevronRight, ArrowLeft } from "lucide-react";
 
 interface ChatMessage {
   id: string;
@@ -40,7 +40,7 @@ function AgentCard({
   return (
     <button
       onClick={onSelect}
-      className={`w-full text-left px-3 py-2.5 rounded-lg transition-colors flex items-center gap-3 ${
+      className={`w-full text-left px-3 py-3 md:py-2.5 rounded-lg transition-colors flex items-center gap-3 min-h-[56px] md:min-h-0 ${
         isSelected
           ? "bg-sidebar-primary text-sidebar-primary-foreground"
           : "hover:bg-sidebar-accent text-sidebar-foreground/80 hover:text-sidebar-accent-foreground"
@@ -66,7 +66,13 @@ function AgentCard({
   );
 }
 
-function ChatPanel({ agent }: { agent: AgentStatus }) {
+function ChatPanel({
+  agent,
+  onBack,
+}: {
+  agent: AgentStatus;
+  onBack: () => void;
+}) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -136,18 +142,26 @@ function ChatPanel({ agent }: { agent: AgentStatus }) {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="px-5 py-3.5 border-b border-border flex items-center gap-3 shrink-0">
+      <div className="px-4 md:px-5 py-3.5 border-b border-border flex items-center gap-3 shrink-0">
+        {/* Back button — mobile only */}
+        <button
+          onClick={onBack}
+          className="md:hidden w-9 h-9 rounded-lg hover:bg-accent flex items-center justify-center -ml-1 shrink-0 transition-colors"
+          aria-label="Back to agents"
+        >
+          <ArrowLeft className="w-4 h-4" />
+        </button>
         <span className="text-2xl">{agent.emoji}</span>
-        <div>
-          <h2 className="text-[14px] font-semibold">{agent.name}</h2>
-          <p className="text-[12px] text-muted-foreground">
+        <div className="min-w-0 flex-1">
+          <h2 className="text-[14px] font-semibold truncate">{agent.name}</h2>
+          <p className="text-[12px] text-muted-foreground truncate">
             {agent.model ?? "No active session"}
             {agent.messageCount !== undefined
               ? ` · ${agent.messageCount} messages`
               : ""}
           </p>
         </div>
-        <div className="ml-auto flex items-center gap-1.5">
+        <div className="ml-auto flex items-center gap-1.5 shrink-0">
           <div
             className={`w-1.5 h-1.5 rounded-full ${
               agent.status === "active"
@@ -184,7 +198,7 @@ function ChatPanel({ agent }: { agent: AgentStatus }) {
               className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
             >
               <div
-                className={`max-w-[80%] rounded-xl px-3.5 py-2.5 text-[13px] leading-relaxed ${
+                className={`max-w-[85%] md:max-w-[80%] rounded-xl px-3.5 py-2.5 text-[13px] leading-relaxed ${
                   msg.role === "user"
                     ? "bg-primary text-primary-foreground"
                     : "bg-muted text-foreground"
@@ -218,8 +232,11 @@ function ChatPanel({ agent }: { agent: AgentStatus }) {
         <div ref={bottomRef} />
       </div>
 
-      {/* Input */}
-      <div className="px-4 py-3 border-t border-border shrink-0">
+      {/* Input — sticky bottom, keyboard-safe */}
+      <div
+        className="px-4 py-3 border-t border-border shrink-0"
+        style={{ paddingBottom: "max(0.75rem, env(safe-area-inset-bottom, 0px))" }}
+      >
         <div className="flex items-end gap-2">
           <textarea
             value={input}
@@ -227,18 +244,19 @@ function ChatPanel({ agent }: { agent: AgentStatus }) {
             onKeyDown={handleKeyDown}
             placeholder={`Message ${agent.name}…`}
             rows={1}
-            className="flex-1 bg-input rounded-xl px-3.5 py-2.5 text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 resize-none min-h-[40px] max-h-[120px]"
+            className="flex-1 bg-input rounded-xl px-3.5 py-2.5 text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 resize-none min-h-[44px] max-h-[120px]"
             style={{ fieldSizing: "content" } as React.CSSProperties}
           />
           <button
             onClick={handleSend}
             disabled={!input.trim() || isPending}
-            className="w-9 h-9 rounded-xl bg-primary text-primary-foreground flex items-center justify-center shrink-0 disabled:opacity-40 hover:bg-primary/90 transition-colors"
+            className="w-11 h-11 rounded-xl bg-primary text-primary-foreground flex items-center justify-center shrink-0 disabled:opacity-40 hover:bg-primary/90 transition-colors"
+            aria-label="Send message"
           >
             <Send className="w-4 h-4" />
           </button>
         </div>
-        <p className="text-[11px] text-muted-foreground mt-1.5 px-1">
+        <p className="hidden md:block text-[11px] text-muted-foreground mt-1.5 px-1">
           Press Enter to send · Shift+Enter for new line
         </p>
       </div>
@@ -255,9 +273,18 @@ export default function AgentsPage() {
   const selectedAgent = agents.find((a) => a.id === selectedAgentId) ?? null;
 
   return (
-    <div className="h-full flex">
-      {/* Agent list sidebar */}
-      <div className="w-56 shrink-0 border-r border-border flex flex-col">
+    <div className="h-full flex overflow-hidden">
+      {/*
+        Agent list panel:
+        - Mobile: full-width, hidden when an agent is selected (chat opens full-screen)
+        - Desktop: always visible as a 224px sidebar
+      */}
+      <div
+        className={`
+          w-full md:w-56 shrink-0 border-r border-border flex flex-col
+          ${selectedAgent ? "hidden md:flex" : "flex"}
+        `}
+      >
         <div className="px-4 py-3.5 border-b border-border">
           <h1 className="text-[14px] font-semibold tracking-tight">Agents</h1>
           <p className="text-[11px] text-muted-foreground mt-0.5">
@@ -265,21 +292,36 @@ export default function AgentsPage() {
           </p>
         </div>
         <div className="flex-1 overflow-y-auto px-2 py-2 space-y-0.5">
-          {agents.map((agent) => (
-            <AgentCard
-              key={agent.id}
-              agent={agent}
-              isSelected={selectedAgentId === agent.id}
-              onSelect={() => setSelectedAgentId(agent.id)}
-            />
-          ))}
+          {agents.length === 0 ? (
+            <div className="p-4 text-center text-[12px] text-muted-foreground">
+              No agents found
+            </div>
+          ) : (
+            agents.map((agent) => (
+              <AgentCard
+                key={agent.id}
+                agent={agent}
+                isSelected={selectedAgentId === agent.id}
+                onSelect={() => setSelectedAgentId(agent.id)}
+              />
+            ))
+          )}
         </div>
       </div>
 
-      {/* Chat area */}
-      <div className="flex-1 min-w-0">
+      {/*
+        Chat area:
+        - Mobile: full-width when agent selected, hidden otherwise
+        - Desktop: flex-1 always
+      */}
+      <div
+        className={`
+          flex-1 min-w-0
+          ${selectedAgent ? "flex flex-col" : "hidden md:flex md:flex-col"}
+        `}
+      >
         {selectedAgent ? (
-          <ChatPanel agent={selectedAgent} />
+          <ChatPanel agent={selectedAgent} onBack={() => setSelectedAgentId(null)} />
         ) : (
           <div className="h-full flex flex-col items-center justify-center text-center gap-4 p-8">
             <div className="flex gap-1">

--- a/apps/clawdash/src/app/agents/page.tsx
+++ b/apps/clawdash/src/app/agents/page.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useSessions } from "@/hooks/use-sessions";
+import { useAgentStatuses, useSendMessage } from "@/hooks/use-agents";
+import type { AgentStatus } from "@/hooks/use-agents";
+import { timeAgo } from "@/lib/utils";
+import { Send, MessageSquare, ChevronRight } from "lucide-react";
+
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+}
+
+function AgentCard({
+  agent,
+  isSelected,
+  onSelect,
+}: {
+  agent: AgentStatus;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const statusColor =
+    agent.status === "active"
+      ? "bg-green-500"
+      : agent.status === "idle"
+        ? "bg-yellow-500"
+        : "bg-muted-foreground/30";
+
+  const statusLabel =
+    agent.status === "active"
+      ? "Active"
+      : agent.status === "idle"
+        ? "Idle"
+        : "Offline";
+
+  return (
+    <button
+      onClick={onSelect}
+      className={`w-full text-left px-3 py-2.5 rounded-lg transition-colors flex items-center gap-3 ${
+        isSelected
+          ? "bg-sidebar-primary text-sidebar-primary-foreground"
+          : "hover:bg-sidebar-accent text-sidebar-foreground/80 hover:text-sidebar-accent-foreground"
+      }`}
+    >
+      <span className="text-xl shrink-0">{agent.emoji}</span>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[13px] font-medium">{agent.name}</span>
+          <div
+            className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusColor} ${
+              agent.status === "active" ? "animate-pulse" : ""
+            }`}
+          />
+        </div>
+        <p className="text-[11px] text-current opacity-60 truncate">
+          {statusLabel}
+          {agent.lastSeen ? ` · ${timeAgo(agent.lastSeen)}` : ""}
+        </p>
+      </div>
+      <ChevronRight className="w-3.5 h-3.5 opacity-40 shrink-0" />
+    </button>
+  );
+}
+
+function ChatPanel({ agent }: { agent: AgentStatus }) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const { mutate: sendMessage, isPending } = useSendMessage();
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  function handleSend() {
+    const text = input.trim();
+    if (!text || isPending) return;
+
+    const userMsg: ChatMessage = {
+      id: String(Date.now()),
+      role: "user",
+      content: text,
+      timestamp: new Date().toISOString(),
+    };
+
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
+
+    sendMessage(
+      {
+        message: text,
+        agentId: agent.id,
+        sessionKey: agent.sessionKey,
+      },
+      {
+        onSuccess: (data) => {
+          const responseText =
+            typeof data.response === "string"
+              ? data.response
+              : data.error
+                ? `Error: ${data.error}`
+                : JSON.stringify(data, null, 2);
+
+          const assistantMsg: ChatMessage = {
+            id: String(Date.now() + 1),
+            role: "assistant",
+            content: responseText,
+            timestamp: new Date().toISOString(),
+          };
+          setMessages((prev) => [...prev, assistantMsg]);
+        },
+        onError: (err) => {
+          const errorMsg: ChatMessage = {
+            id: String(Date.now() + 1),
+            role: "assistant",
+            content: `Failed to send message: ${err.message}`,
+            timestamp: new Date().toISOString(),
+          };
+          setMessages((prev) => [...prev, errorMsg]);
+        },
+      }
+    );
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="px-5 py-3.5 border-b border-border flex items-center gap-3 shrink-0">
+        <span className="text-2xl">{agent.emoji}</span>
+        <div>
+          <h2 className="text-[14px] font-semibold">{agent.name}</h2>
+          <p className="text-[12px] text-muted-foreground">
+            {agent.model ?? "No active session"}
+            {agent.messageCount !== undefined
+              ? ` · ${agent.messageCount} messages`
+              : ""}
+          </p>
+        </div>
+        <div className="ml-auto flex items-center gap-1.5">
+          <div
+            className={`w-1.5 h-1.5 rounded-full ${
+              agent.status === "active"
+                ? "bg-green-500 animate-pulse"
+                : agent.status === "idle"
+                  ? "bg-yellow-500"
+                  : "bg-muted-foreground/30"
+            }`}
+          />
+          <span className="text-[12px] text-muted-foreground capitalize">
+            {agent.status}
+          </span>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {messages.length === 0 ? (
+          <div className="h-full flex flex-col items-center justify-center text-center gap-3">
+            <MessageSquare className="w-10 h-10 text-muted-foreground/30" />
+            <div>
+              <p className="text-[14px] font-medium text-muted-foreground">
+                No messages yet
+              </p>
+              <p className="text-[12px] text-muted-foreground mt-1">
+                Send a message to {agent.name} to start a conversation
+              </p>
+            </div>
+          </div>
+        ) : (
+          messages.map((msg) => (
+            <div
+              key={msg.id}
+              className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+            >
+              <div
+                className={`max-w-[80%] rounded-xl px-3.5 py-2.5 text-[13px] leading-relaxed ${
+                  msg.role === "user"
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-foreground"
+                }`}
+              >
+                <p className="whitespace-pre-wrap break-words">{msg.content}</p>
+                <p
+                  className={`text-[10px] mt-1 ${
+                    msg.role === "user"
+                      ? "text-primary-foreground/60 text-right"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  {timeAgo(msg.timestamp)}
+                </p>
+              </div>
+            </div>
+          ))
+        )}
+        {isPending && (
+          <div className="flex justify-start">
+            <div className="bg-muted rounded-xl px-3.5 py-2.5">
+              <div className="flex gap-1 items-center h-4">
+                <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:0ms]" />
+                <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:150ms]" />
+                <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:300ms]" />
+              </div>
+            </div>
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input */}
+      <div className="px-4 py-3 border-t border-border shrink-0">
+        <div className="flex items-end gap-2">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={`Message ${agent.name}…`}
+            rows={1}
+            className="flex-1 bg-input rounded-xl px-3.5 py-2.5 text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 resize-none min-h-[40px] max-h-[120px]"
+            style={{ fieldSizing: "content" } as React.CSSProperties}
+          />
+          <button
+            onClick={handleSend}
+            disabled={!input.trim() || isPending}
+            className="w-9 h-9 rounded-xl bg-primary text-primary-foreground flex items-center justify-center shrink-0 disabled:opacity-40 hover:bg-primary/90 transition-colors"
+          >
+            <Send className="w-4 h-4" />
+          </button>
+        </div>
+        <p className="text-[11px] text-muted-foreground mt-1.5 px-1">
+          Press Enter to send · Shift+Enter for new line
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function AgentsPage() {
+  const { data: sessionsData } = useSessions();
+  const sessions = sessionsData?.sessions ?? [];
+  const agents = useAgentStatuses(sessions);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+
+  const selectedAgent = agents.find((a) => a.id === selectedAgentId) ?? null;
+
+  return (
+    <div className="h-full flex">
+      {/* Agent list sidebar */}
+      <div className="w-56 shrink-0 border-r border-border flex flex-col">
+        <div className="px-4 py-3.5 border-b border-border">
+          <h1 className="text-[14px] font-semibold tracking-tight">Agents</h1>
+          <p className="text-[11px] text-muted-foreground mt-0.5">
+            Chat with active agents
+          </p>
+        </div>
+        <div className="flex-1 overflow-y-auto px-2 py-2 space-y-0.5">
+          {agents.map((agent) => (
+            <AgentCard
+              key={agent.id}
+              agent={agent}
+              isSelected={selectedAgentId === agent.id}
+              onSelect={() => setSelectedAgentId(agent.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Chat area */}
+      <div className="flex-1 min-w-0">
+        {selectedAgent ? (
+          <ChatPanel agent={selectedAgent} />
+        ) : (
+          <div className="h-full flex flex-col items-center justify-center text-center gap-4 p-8">
+            <div className="flex gap-1">
+              {agents.slice(0, 3).map((a) => (
+                <span key={a.id} className="text-3xl">
+                  {a.emoji}
+                </span>
+              ))}
+            </div>
+            <div>
+              <p className="text-[15px] font-semibold">Select an agent</p>
+              <p className="text-[13px] text-muted-foreground mt-1">
+                Choose an agent from the list to start chatting
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/clawdash/src/app/api/agents/route.ts
+++ b/apps/clawdash/src/app/api/agents/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const KNOWN_AGENTS = [
+  { id: "main", name: "Ash", emoji: "🔥" },
+  { id: "ocean", name: "Ocean", emoji: "🌊" },
+  { id: "skylar", name: "Skylar", emoji: "⚡" },
+  { id: "coral", name: "Coral", emoji: "🪸" },
+  { id: "arctic", name: "Arctic", emoji: "🧊" },
+];
+
+export async function GET() {
+  return NextResponse.json({ agents: KNOWN_AGENTS });
+}

--- a/apps/clawdash/src/app/api/crons/[id]/run/route.ts
+++ b/apps/clawdash/src/app/api/crons/[id]/run/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { listCronJobs } from "@/lib/openclaw";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const jobs = await listCronJobs();
+    const job = jobs.find((j) => j.id === id);
+    if (!job) {
+      return NextResponse.json({ error: "Job not found" }, { status: 404 });
+    }
+    // Fire a run-now via openclaw gateway if available
+    const gatewayUrl = process.env.OPENCLAW_GATEWAY_URL ?? "http://127.0.0.1:18789";
+    const httpBase = gatewayUrl.replace(/^ws/, "http");
+    try {
+      const res = await fetch(`${httpBase}/api/cron/${id}/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      if (res.ok) {
+        return NextResponse.json({ success: true, queued: true });
+      }
+    } catch {
+      // Gateway not available or endpoint not found — return a best-effort response
+    }
+    return NextResponse.json({ success: true, queued: false, note: "Gateway unavailable; job not triggered live" });
+  } catch {
+    return NextResponse.json({ error: "Failed to run cron job" }, { status: 500 });
+  }
+}

--- a/apps/clawdash/src/app/api/crons/[id]/toggle/route.ts
+++ b/apps/clawdash/src/app/api/crons/[id]/toggle/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { toggleCronJob } from "@/lib/openclaw";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json() as { enabled: boolean };
+    const ok = await toggleCronJob(id, body.enabled);
+    if (!ok) {
+      return NextResponse.json({ error: "Job not found" }, { status: 404 });
+    }
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ error: "Failed to toggle cron job" }, { status: 500 });
+  }
+}

--- a/apps/clawdash/src/app/api/message/route.ts
+++ b/apps/clawdash/src/app/api/message/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const SERVER_BASE =
+  process.env.OPENCLAW_SERVER_URL ?? "http://localhost:3001";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json() as { message: string; agentId?: string; sessionKey?: string };
+    const res = await fetch(`${SERVER_BASE}/api/openclaw/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json();
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+    return NextResponse.json(data);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to send message";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/apps/clawdash/src/app/api/session-messages/route.ts
+++ b/apps/clawdash/src/app/api/session-messages/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { getOpenClawDir, getAgentId } from "@/lib/openclaw";
+import { existsSync } from "fs";
+
+export const dynamic = "force-dynamic";
+
+interface JournalEntry {
+  type: string;
+  id?: string;
+  timestamp?: string;
+  message?: {
+    role?: string;
+    content?: string | Array<{ type: string; text?: string }>;
+    timestamp?: number;
+  };
+}
+
+export interface SessionMessage {
+  id: string;
+  role: "user" | "assistant" | "tool";
+  content: string;
+  timestamp: string;
+}
+
+function extractText(
+  content: string | Array<{ type: string; text?: string }>
+): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((c) => c.type === "text")
+      .map((c) => c.text ?? "")
+      .join("\n")
+      .trim();
+  }
+  return "";
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const sessionId = searchParams.get("sessionId");
+  const agentId = searchParams.get("agentId") ?? getAgentId();
+  const limit = Math.min(parseInt(searchParams.get("limit") ?? "50"), 200);
+
+  if (!sessionId) {
+    return NextResponse.json({ error: "sessionId required" }, { status: 400 });
+  }
+
+  const sessionsDir = join(getOpenClawDir(), "agents", agentId, "sessions");
+  const filePath = join(sessionsDir, `${sessionId}.jsonl`);
+
+  if (!existsSync(filePath)) {
+    return NextResponse.json({ messages: [] });
+  }
+
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const lines = raw.trim().split("\n").filter(Boolean);
+
+    const messages: SessionMessage[] = [];
+
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as JournalEntry;
+        if (entry.type !== "message" || !entry.message) continue;
+
+        const role = entry.message.role;
+        if (role !== "user" && role !== "assistant") continue;
+
+        const content = extractText(entry.message.content ?? "");
+        if (!content.trim()) continue;
+
+        messages.push({
+          id: entry.id ?? String(messages.length),
+          role: role as "user" | "assistant",
+          content,
+          timestamp:
+            entry.timestamp ??
+            (entry.message.timestamp
+              ? new Date(entry.message.timestamp).toISOString()
+              : new Date().toISOString()),
+        });
+      } catch {
+        // skip malformed lines
+      }
+    }
+
+    // Return last N messages
+    return NextResponse.json({ messages: messages.slice(-limit) });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to read session" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/clawdash/src/app/config/page.tsx
+++ b/apps/clawdash/src/app/config/page.tsx
@@ -69,7 +69,7 @@ export default function ConfigPage() {
   }
 
   return (
-    <div className="p-6 space-y-5 max-w-4xl">
+    <div className="p-4 md:p-6 space-y-5 max-w-4xl">
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Config</h1>
         <p className="text-[13px] text-muted-foreground mt-1">

--- a/apps/clawdash/src/app/costs/page.tsx
+++ b/apps/clawdash/src/app/costs/page.tsx
@@ -17,7 +17,7 @@ export default function CostsPage() {
   const maxDayCost = Math.max(...dayEntries.map(([, v]) => v), 1);
 
   return (
-    <div className="p-6 space-y-6 max-w-6xl">
+    <div className="p-4 md:p-6 space-y-5 md:space-y-6 max-w-6xl">
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Costs</h1>
         <p className="text-[13px] text-muted-foreground mt-1">
@@ -25,31 +25,33 @@ export default function CostsPage() {
         </p>
       </div>
 
-      <div className="flex items-center gap-3">
-        <div className="rounded-xl border border-border bg-card p-5 flex-1">
+      {/* Summary cards — stack on mobile, row on md+ */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-xl border border-border bg-card p-4 md:p-5">
           <div className="flex items-center gap-2 mb-1">
             <DollarSign className="w-4 h-4 text-warning" />
             <span className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
               Total Spend
             </span>
           </div>
-          <p className="text-3xl font-semibold tracking-tight">
+          <p className="text-2xl md:text-3xl font-semibold tracking-tight">
             {formatCost(data?.totalCents || 0)}
           </p>
         </div>
-        <div className="rounded-xl border border-border bg-card p-5 flex-1">
+        <div className="rounded-xl border border-border bg-card p-4 md:p-5">
           <div className="flex items-center gap-2 mb-1">
             <TrendingUp className="w-4 h-4 text-primary" />
             <span className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
               Models Used
             </span>
           </div>
-          <p className="text-3xl font-semibold tracking-tight">
+          <p className="text-2xl md:text-3xl font-semibold tracking-tight">
             {modelEntries.length}
           </p>
         </div>
       </div>
 
+      {/* By model + by day — stack on mobile, 2-col on lg */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <div className="rounded-xl border border-border bg-card">
           <div className="px-4 py-3 border-b border-border">
@@ -63,9 +65,9 @@ export default function CostsPage() {
             ) : (
               modelEntries.map(([model, cost]) => (
                 <div key={model} className="space-y-1.5">
-                  <div className="flex items-center justify-between text-[13px]">
+                  <div className="flex items-center justify-between text-[13px] gap-2">
                     <span className="truncate">{model}</span>
-                    <span className="font-mono shrink-0 ml-2">
+                    <span className="font-mono shrink-0">
                       {formatCost(cost)}
                     </span>
                   </div>
@@ -93,11 +95,11 @@ export default function CostsPage() {
             ) : (
               dayEntries.slice(0, 14).map(([day, cost]) => (
                 <div key={day} className="space-y-1.5">
-                  <div className="flex items-center justify-between text-[13px]">
-                    <span className="font-mono text-muted-foreground">
+                  <div className="flex items-center justify-between text-[13px] gap-2">
+                    <span className="font-mono text-muted-foreground shrink-0">
                       {day}
                     </span>
-                    <span className="font-mono shrink-0 ml-2">
+                    <span className="font-mono shrink-0">
                       {formatCost(cost)}
                     </span>
                   </div>
@@ -114,6 +116,7 @@ export default function CostsPage() {
         </div>
       </div>
 
+      {/* By session */}
       <div className="rounded-xl border border-border bg-card">
         <div className="px-4 py-3 border-b border-border">
           <span className="text-[13px] font-semibold">By Session</span>
@@ -127,17 +130,17 @@ export default function CostsPage() {
             bySession.slice(0, 20).map((s) => (
               <div
                 key={s.id}
-                className="px-4 py-2.5 flex items-center justify-between"
+                className="px-4 py-3 flex items-center justify-between gap-3 min-h-[52px]"
               >
-                <div className="min-w-0">
+                <div className="min-w-0 flex-1">
                   <span className="text-[13px] font-mono truncate block">
-                    {s.id.slice(0, 16)}
+                    {s.id.slice(0, 20)}
                   </span>
-                  <span className="text-[11px] text-muted-foreground">
+                  <span className="text-[11px] text-muted-foreground truncate block mt-0.5">
                     {s.model}
                   </span>
                 </div>
-                <span className="text-[13px] font-mono shrink-0 ml-3">
+                <span className="text-[13px] font-mono shrink-0">
                   {formatCost(s.costCents)}
                 </span>
               </div>

--- a/apps/clawdash/src/app/cron/page.tsx
+++ b/apps/clawdash/src/app/cron/page.tsx
@@ -9,7 +9,7 @@ export default function CronPage() {
   const jobs = data?.jobs || [];
 
   return (
-    <div className="p-6 space-y-5 max-w-4xl">
+    <div className="p-4 md:p-6 space-y-5 max-w-4xl">
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Cron Jobs</h1>
         <p className="text-[13px] text-muted-foreground mt-1">
@@ -31,7 +31,7 @@ export default function CronPage() {
             {jobs.map((job) => (
               <div
                 key={job.id}
-                className="px-5 py-4 flex items-center gap-4"
+                className="px-4 md:px-5 py-4 flex items-center gap-3 md:gap-4 min-h-[64px]"
               >
                 <div
                   className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${

--- a/apps/clawdash/src/app/files/page.tsx
+++ b/apps/clawdash/src/app/files/page.tsx
@@ -74,7 +74,7 @@ export default function FilesPage() {
   }
 
   return (
-    <div className="p-6 space-y-5 max-w-6xl">
+    <div className="p-4 md:p-6 space-y-5 max-w-6xl">
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Files</h1>
         <p className="text-[13px] text-muted-foreground mt-1">

--- a/apps/clawdash/src/app/globals.css
+++ b/apps/clawdash/src/app/globals.css
@@ -4,6 +4,16 @@
 html,
 body {
   height: 100%;
+  overflow-x: hidden;
+}
+
+/* Safe-area utilities for iOS */
+.pb-safe {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+.pb-safe-nav {
+  padding-bottom: calc(4rem + env(safe-area-inset-bottom, 0px));
 }
 
 body {

--- a/apps/clawdash/src/app/layout.tsx
+++ b/apps/clawdash/src/app/layout.tsx
@@ -19,6 +19,7 @@ export const metadata: Metadata = {
   title: `ClawDash — ${appConfig.name}`,
   description: "OpenClaw agent diagnostics dashboard",
   icons: { icon: "/favicon.svg" },
+  viewport: "width=device-width, initial-scale=1, viewport-fit=cover",
 };
 
 export default function RootLayout({
@@ -29,13 +30,21 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body
-        className={`${inter.variable} ${jetbrainsMono.variable} font-sans bg-background text-foreground antialiased`}
+        className={`${inter.variable} ${jetbrainsMono.variable} font-sans bg-background text-foreground antialiased overflow-x-hidden`}
       >
         <Providers>
           <div className="flex h-screen overflow-hidden">
             <AppSidebar />
             <main className="flex-1 overflow-y-auto">
-              <div className="animate-fade-in-up">{children}</div>
+              {/* Mobile top header — shows app name, hidden on desktop */}
+              <div className="md:hidden flex items-center gap-2.5 h-12 px-4 border-b border-border bg-sidebar sticky top-0 z-10">
+                <div className="w-6 h-6 rounded-md bg-primary flex items-center justify-center text-xs">
+                  🦞
+                </div>
+                <span className="text-sm font-semibold tracking-tight">ClawDash</span>
+              </div>
+              {/* Bottom padding on mobile so content clears the tab bar */}
+              <div className="animate-fade-in-up pb-16 md:pb-0">{children}</div>
             </main>
           </div>
         </Providers>

--- a/apps/clawdash/src/app/live-feed/page.tsx
+++ b/apps/clawdash/src/app/live-feed/page.tsx
@@ -7,8 +7,8 @@ export default function LiveFeedPage() {
   const { messages, connected, paused, togglePause, clear } = useLiveFeed();
 
   return (
-    <div className="p-6 space-y-5 max-w-4xl">
-      <div className="flex items-center justify-between">
+    <div className="p-4 md:p-6 space-y-5 max-w-4xl">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h1 className="text-xl font-semibold tracking-tight">Live Feed</h1>
           <p className="text-[13px] text-muted-foreground mt-1">
@@ -26,7 +26,7 @@ export default function LiveFeedPage() {
           </div>
           <button
             onClick={togglePause}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] rounded-lg bg-muted hover:bg-muted/80 transition-colors"
+            className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 text-[12px] rounded-lg bg-muted hover:bg-muted/80 transition-colors min-h-[44px] md:min-h-0"
           >
             {paused ? (
               <Play className="w-3 h-3" />
@@ -37,7 +37,7 @@ export default function LiveFeedPage() {
           </button>
           <button
             onClick={clear}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] rounded-lg bg-muted hover:bg-muted/80 transition-colors"
+            className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 text-[12px] rounded-lg bg-muted hover:bg-muted/80 transition-colors min-h-[44px] md:min-h-0"
           >
             <Trash2 className="w-3 h-3" />
             Clear

--- a/apps/clawdash/src/app/logs/page.tsx
+++ b/apps/clawdash/src/app/logs/page.tsx
@@ -28,7 +28,7 @@ export default function LogsPage() {
   const logLines = data?.lines || [];
 
   return (
-    <div className="p-6 space-y-5 max-w-5xl">
+    <div className="p-4 md:p-6 space-y-4 md:space-y-5 max-w-5xl">
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Logs</h1>
         <p className="text-[13px] text-muted-foreground mt-1">
@@ -36,13 +36,14 @@ export default function LogsPage() {
         </p>
       </div>
 
-      <div className="flex items-center gap-3">
-        <div className="flex items-center gap-1 p-0.5 rounded-lg bg-muted">
+      {/* Controls — wrap on mobile */}
+      <div className="flex flex-wrap items-center gap-2 md:gap-3">
+        <div className="flex items-center gap-1 p-0.5 rounded-lg bg-muted overflow-x-auto">
           {SERVICES.map((s) => (
             <button
               key={s}
               onClick={() => setService(s)}
-              className={`px-3 py-1 text-[12px] rounded-md transition-colors ${
+              className={`px-3 py-1.5 md:py-1 text-[12px] rounded-md transition-colors whitespace-nowrap min-h-[36px] md:min-h-0 ${
                 service === s
                   ? "bg-background text-foreground font-medium shadow-sm"
                   : "text-muted-foreground hover:text-foreground"
@@ -55,7 +56,7 @@ export default function LogsPage() {
         <select
           value={lines}
           onChange={(e) => setLines(Number(e.target.value))}
-          className="h-8 px-2 rounded-lg bg-muted text-[12px] border-none focus:outline-none focus:ring-2 focus:ring-ring/50"
+          className="h-10 md:h-8 px-2 rounded-lg bg-muted text-[12px] border-none focus:outline-none focus:ring-2 focus:ring-ring/50"
         >
           <option value={50}>50 lines</option>
           <option value={100}>100 lines</option>
@@ -64,7 +65,7 @@ export default function LogsPage() {
         </select>
         <button
           onClick={() => refetch()}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] rounded-lg bg-muted hover:bg-muted/80 transition-colors"
+          className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 text-[12px] rounded-lg bg-muted hover:bg-muted/80 transition-colors min-h-[44px] md:min-h-0"
         >
           <RefreshCw className={`w-3 h-3 ${isLoading ? "animate-spin" : ""}`} />
           Refresh
@@ -79,13 +80,13 @@ export default function LogsPage() {
             ({logLines.length} lines · {data?.platform || "unknown"})
           </span>
         </div>
-        <div className="max-h-[calc(100vh-280px)] overflow-y-auto p-4 bg-[oklch(0.12_0_0)]">
+        <div className="max-h-[calc(100vh-280px)] overflow-y-auto p-3 md:p-4 bg-[oklch(0.12_0_0)]">
           {logLines.length === 0 ? (
             <p className="text-[13px] text-muted-foreground text-center py-8">
               No logs available for this service
             </p>
           ) : (
-            <pre className="text-[12px] font-mono leading-relaxed text-muted-foreground whitespace-pre-wrap break-all">
+            <pre className="text-[11px] md:text-[12px] font-mono leading-relaxed text-muted-foreground whitespace-pre-wrap break-all">
               {logLines.join("\n")}
             </pre>
           )}

--- a/apps/clawdash/src/app/memory/page.tsx
+++ b/apps/clawdash/src/app/memory/page.tsx
@@ -14,7 +14,7 @@ export default function MemoryPage() {
   const files = filesData?.files || [];
 
   return (
-    <div className="p-6 space-y-5 max-w-6xl">
+    <div className="p-4 md:p-6 space-y-5 max-w-6xl">
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Memory</h1>
         <p className="text-[13px] text-muted-foreground mt-1">
@@ -38,7 +38,7 @@ export default function MemoryPage() {
                 <button
                   key={f.path}
                   onClick={() => setSelectedPath(f.path)}
-                  className={`w-full text-left px-4 py-2.5 flex items-center gap-3 transition-colors ${
+                  className={`w-full text-left px-4 py-3 md:py-2.5 flex items-center gap-3 transition-colors min-h-[52px] md:min-h-0 ${
                     selectedPath === f.path
                       ? "bg-primary/10 text-primary"
                       : "hover:bg-accent"

--- a/apps/clawdash/src/app/page.tsx
+++ b/apps/clawdash/src/app/page.tsx
@@ -3,7 +3,9 @@
 import { useSessions } from "@/hooks/use-sessions";
 import { useSystemHealth } from "@/hooks/use-system-health";
 import { useCosts } from "@/hooks/use-costs";
+import { useAgentStatuses } from "@/hooks/use-agents";
 import { formatBytes, formatNumber, formatCost } from "@/lib/utils";
+import { AgentStatusCards } from "@/components/agents/agent-status-cards";
 import {
   Activity,
   Cpu,
@@ -114,9 +116,9 @@ function SessionsPreview({
               <div
                 className={`w-1.5 h-1.5 rounded-full shrink-0 ${
                   s.status === "active"
-                    ? "bg-success animate-pulse"
+                    ? "bg-green-500 animate-pulse"
                     : s.status === "idle"
-                      ? "bg-warning"
+                      ? "bg-yellow-500"
                       : "bg-muted-foreground/30"
                 }`}
               />
@@ -147,6 +149,7 @@ export default function OverviewPage() {
   const { data: costsData } = useCosts();
 
   const sessions = sessionsData?.sessions || [];
+  const agentStatuses = useAgentStatuses(sessions);
   const activeSessions = sessions.filter((s) => s.status === "active").length;
   const totalTokens = sessions.reduce(
     (sum, s) => sum + s.tokensIn + s.tokensOut,
@@ -163,6 +166,7 @@ export default function OverviewPage() {
         </p>
       </div>
 
+      <AgentStatusCards agents={agentStatuses} />
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <StatCard
           label="Active Sessions"

--- a/apps/clawdash/src/app/page.tsx
+++ b/apps/clawdash/src/app/page.tsx
@@ -112,9 +112,9 @@ function SessionsPreview({
       ) : (
         <div className="divide-y divide-border">
           {recent.map((s) => (
-            <div key={s.id} className="px-4 py-2.5 flex items-center gap-3">
+            <div key={s.id} className="px-4 py-3 flex items-center gap-3">
               <div
-                className={`w-1.5 h-1.5 rounded-full shrink-0 ${
+                className={`w-2 h-2 rounded-full shrink-0 ${
                   s.status === "active"
                     ? "bg-green-500 animate-pulse"
                     : s.status === "idle"
@@ -158,7 +158,7 @@ export default function OverviewPage() {
   const totalMessages = sessions.reduce((sum, s) => sum + s.messageCount, 0);
 
   return (
-    <div className="p-6 space-y-6 max-w-6xl">
+    <div className="p-4 md:p-6 space-y-5 md:space-y-6 max-w-6xl">
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Overview</h1>
         <p className="text-[13px] text-muted-foreground mt-1">
@@ -167,6 +167,8 @@ export default function OverviewPage() {
       </div>
 
       <AgentStatusCards agents={agentStatuses} />
+
+      {/* Stat cards: 2-col on mobile, 4-col on large */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <StatCard
           label="Active Sessions"
@@ -197,7 +199,8 @@ export default function OverviewPage() {
         />
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
+      {/* Health gauges: stack on mobile, 3-col on large */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
         <HealthGauge
           label="CPU"
           value={healthData?.cpu.usage || 0}
@@ -221,6 +224,7 @@ export default function OverviewPage() {
         />
       </div>
 
+      {/* Sessions + System Info: stack on mobile, 2-col on large */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <SessionsPreview sessions={sessions} />
         <div className="rounded-xl border border-border bg-card">

--- a/apps/clawdash/src/app/rate-limits/page.tsx
+++ b/apps/clawdash/src/app/rate-limits/page.tsx
@@ -16,7 +16,7 @@ export default function RateLimitsPage() {
   const usage = data?.usage || [];
 
   return (
-    <div className="p-6 space-y-6 max-w-4xl">
+    <div className="p-4 md:p-6 space-y-5 md:space-y-6 max-w-4xl">
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Rate Limits</h1>
         <p className="text-[13px] text-muted-foreground mt-1">
@@ -41,20 +41,20 @@ export default function RateLimitsPage() {
             return (
               <div
                 key={u.model}
-                className="rounded-xl border border-border bg-card p-5 space-y-3"
+                className="rounded-xl border border-border bg-card p-4 md:p-5 space-y-3"
               >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
                     <Gauge
-                      className="w-4 h-4"
+                      className="w-4 h-4 shrink-0"
                       style={{ color }}
                     />
-                    <span className="text-[13px] font-medium">
+                    <span className="text-[13px] font-medium truncate">
                       {u.model}
                     </span>
                   </div>
                   <span
-                    className={`text-[12px] font-mono ${
+                    className={`text-[12px] font-mono shrink-0 ${
                       isNear ? "text-destructive" : "text-muted-foreground"
                     }`}
                   >

--- a/apps/clawdash/src/app/sessions/page.tsx
+++ b/apps/clawdash/src/app/sessions/page.tsx
@@ -18,7 +18,7 @@ function MessageViewer({
 
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50">
-      <div className="bg-card border border-border rounded-2xl w-full max-w-2xl max-h-[80vh] flex flex-col mx-4 sm:mx-0">
+      <div className="bg-card border border-border rounded-2xl w-full max-w-2xl max-h-[85vh] sm:max-h-[80vh] flex flex-col mx-0 sm:mx-4 rounded-b-none sm:rounded-b-2xl">
         <div className="px-5 py-3.5 border-b border-border flex items-center justify-between shrink-0">
           <div>
             <h3 className="text-[14px] font-semibold">Session Messages</h3>
@@ -28,7 +28,8 @@ function MessageViewer({
           </div>
           <button
             onClick={onClose}
-            className="w-7 h-7 rounded-lg hover:bg-accent flex items-center justify-center transition-colors"
+            className="w-10 h-10 rounded-lg hover:bg-accent flex items-center justify-center transition-colors"
+            aria-label="Close"
           >
             <X className="w-4 h-4" />
           </button>
@@ -75,7 +76,10 @@ function MessageViewer({
           )}
         </div>
 
-        <div className="px-4 py-2.5 border-t border-border shrink-0">
+        <div
+          className="px-4 py-2.5 border-t border-border shrink-0"
+          style={{ paddingBottom: "max(0.625rem, env(safe-area-inset-bottom, 0px))" }}
+        >
           <p className="text-[11px] text-muted-foreground">
             Showing last {messages.length} messages
           </p>
@@ -113,15 +117,16 @@ export default function SessionsPage() {
   const statuses = ["all", "active", "idle", "closed"];
 
   return (
-    <div className="p-6 space-y-5 max-w-6xl">
+    <div className="p-4 md:p-6 space-y-5 max-w-6xl">
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Sessions</h1>
         <p className="text-[13px] text-muted-foreground mt-1">
-          All agent sessions and their activity — click a row to view messages
+          All agent sessions and their activity — tap a row to view messages
         </p>
       </div>
 
-      <div className="flex items-center gap-3">
+      {/* Search + filters */}
+      <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3">
         <div className="flex-1 relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <input
@@ -129,15 +134,15 @@ export default function SessionsPage() {
             placeholder="Search sessions…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="w-full h-9 pl-9 pr-3 rounded-full bg-input text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
+            className="w-full h-11 md:h-9 pl-9 pr-3 rounded-full bg-input text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
           />
         </div>
-        <div className="flex items-center gap-1 p-0.5 rounded-lg bg-muted">
+        <div className="flex items-center gap-1 p-0.5 rounded-lg bg-muted overflow-x-auto">
           {statuses.map((s) => (
             <button
               key={s}
               onClick={() => setStatusFilter(s)}
-              className={`px-3 py-1 text-[12px] rounded-md capitalize transition-colors ${
+              className={`px-3 py-1.5 md:py-1 text-[12px] rounded-md capitalize transition-colors whitespace-nowrap min-h-[36px] md:min-h-0 ${
                 statusFilter === s
                   ? "bg-background text-foreground font-medium shadow-sm"
                   : "text-muted-foreground hover:text-foreground"
@@ -149,7 +154,8 @@ export default function SessionsPage() {
         </div>
       </div>
 
-      <div className="rounded-xl border border-border bg-card overflow-hidden">
+      {/* Desktop table — hidden on mobile */}
+      <div className="hidden md:block rounded-xl border border-border bg-card overflow-hidden">
         <div className="grid grid-cols-[1fr_1fr_100px_100px_100px_80px_100px_32px] gap-2 px-4 py-2.5 border-b border-border text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
           <span>Session</span>
           <span>Model</span>
@@ -210,6 +216,69 @@ export default function SessionsPage() {
               </div>
             ))}
           </div>
+        )}
+      </div>
+
+      {/* Mobile card list — shown on mobile only */}
+      <div className="md:hidden space-y-2">
+        {filtered.length === 0 ? (
+          <div className="rounded-xl border border-border bg-card p-8 text-center text-[13px] text-muted-foreground">
+            {sessions.length === 0
+              ? "No sessions found. Is OpenClaw running?"
+              : "No sessions match your filters."}
+          </div>
+        ) : (
+          filtered.map((s) => (
+            <button
+              key={s.id}
+              onClick={() => setSelectedSessionId(s.id)}
+              className="w-full text-left rounded-xl border border-border bg-card p-4 hover:bg-accent/50 transition-colors"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <div
+                    className={`w-2 h-2 rounded-full shrink-0 mt-0.5 ${
+                      s.status === "active"
+                        ? "bg-green-500 animate-pulse"
+                        : s.status === "idle"
+                          ? "bg-yellow-500"
+                          : "bg-muted-foreground/30"
+                    }`}
+                  />
+                  <div className="min-w-0">
+                    <p className="text-[13px] font-mono font-medium truncate">
+                      {s.id.slice(0, 20)}
+                    </p>
+                    <p className="text-[11px] text-muted-foreground truncate mt-0.5">
+                      {s.model}
+                    </p>
+                  </div>
+                </div>
+                <ChevronRight className="w-4 h-4 text-muted-foreground/40 shrink-0 mt-0.5" />
+              </div>
+              <div className="mt-3 grid grid-cols-4 gap-2 text-center">
+                <div>
+                  <p className="text-[11px] text-muted-foreground">Tokens In</p>
+                  <p className="text-[13px] font-mono mt-0.5">{formatNumber(s.tokensIn)}</p>
+                </div>
+                <div>
+                  <p className="text-[11px] text-muted-foreground">Tokens Out</p>
+                  <p className="text-[13px] font-mono mt-0.5">{formatNumber(s.tokensOut)}</p>
+                </div>
+                <div>
+                  <p className="text-[11px] text-muted-foreground">Msgs</p>
+                  <p className="text-[13px] font-mono mt-0.5">{s.messageCount}</p>
+                </div>
+                <div>
+                  <p className="text-[11px] text-muted-foreground">Cost</p>
+                  <p className="text-[13px] font-mono mt-0.5">{formatCost(s.costCents)}</p>
+                </div>
+              </div>
+              <p className="text-[11px] text-muted-foreground mt-2">
+                Updated {timeAgo(s.updatedAt)}
+              </p>
+            </button>
+          ))
         )}
       </div>
 

--- a/apps/clawdash/src/app/sessions/page.tsx
+++ b/apps/clawdash/src/app/sessions/page.tsx
@@ -2,13 +2,96 @@
 
 import { useState, useMemo } from "react";
 import { useSessions } from "@/hooks/use-sessions";
+import { useSessionMessages } from "@/hooks/use-session-messages";
 import { formatNumber, formatCost, timeAgo } from "@/lib/utils";
-import { Search, Filter } from "lucide-react";
+import { Search, X, MessageSquare, ChevronRight } from "lucide-react";
+
+function MessageViewer({
+  sessionId,
+  onClose,
+}: {
+  sessionId: string;
+  onClose: () => void;
+}) {
+  const { data, isLoading } = useSessionMessages(sessionId);
+  const messages = data?.messages ?? [];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50">
+      <div className="bg-card border border-border rounded-2xl w-full max-w-2xl max-h-[80vh] flex flex-col mx-4 sm:mx-0">
+        <div className="px-5 py-3.5 border-b border-border flex items-center justify-between shrink-0">
+          <div>
+            <h3 className="text-[14px] font-semibold">Session Messages</h3>
+            <p className="text-[11px] text-muted-foreground font-mono mt-0.5">
+              {sessionId.slice(0, 24)}…
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 rounded-lg hover:bg-accent flex items-center justify-center transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          {isLoading ? (
+            <div className="text-center py-8 text-[13px] text-muted-foreground">
+              Loading messages…
+            </div>
+          ) : messages.length === 0 ? (
+            <div className="text-center py-8 text-[13px] text-muted-foreground flex flex-col items-center gap-2">
+              <MessageSquare className="w-8 h-8 opacity-30" />
+              No messages found for this session.
+            </div>
+          ) : (
+            messages.map((msg) => (
+              <div
+                key={msg.id}
+                className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  className={`max-w-[85%] rounded-xl px-3.5 py-2.5 text-[13px] leading-relaxed ${
+                    msg.role === "user"
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-foreground"
+                  }`}
+                >
+                  <p className="whitespace-pre-wrap break-words line-clamp-10">
+                    {msg.content}
+                  </p>
+                  <p
+                    className={`text-[10px] mt-1 ${
+                      msg.role === "user"
+                        ? "text-primary-foreground/60 text-right"
+                        : "text-muted-foreground"
+                    }`}
+                  >
+                    {timeAgo(msg.timestamp)}
+                  </p>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="px-4 py-2.5 border-t border-border shrink-0">
+          <p className="text-[11px] text-muted-foreground">
+            Showing last {messages.length} messages
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function SessionsPage() {
   const { data } = useSessions();
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
+    null
+  );
 
   const sessions = data?.sessions || [];
 
@@ -34,7 +117,7 @@ export default function SessionsPage() {
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Sessions</h1>
         <p className="text-[13px] text-muted-foreground mt-1">
-          All agent sessions and their activity
+          All agent sessions and their activity — click a row to view messages
         </p>
       </div>
 
@@ -43,7 +126,7 @@ export default function SessionsPage() {
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <input
             type="text"
-            placeholder="Search sessions..."
+            placeholder="Search sessions…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="w-full h-9 pl-9 pr-3 rounded-full bg-input text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
@@ -67,7 +150,7 @@ export default function SessionsPage() {
       </div>
 
       <div className="rounded-xl border border-border bg-card overflow-hidden">
-        <div className="grid grid-cols-[1fr_1fr_100px_100px_100px_80px_100px] gap-2 px-4 py-2.5 border-b border-border text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
+        <div className="grid grid-cols-[1fr_1fr_100px_100px_100px_80px_100px_32px] gap-2 px-4 py-2.5 border-b border-border text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
           <span>Session</span>
           <span>Model</span>
           <span className="text-right">Tokens In</span>
@@ -75,6 +158,7 @@ export default function SessionsPage() {
           <span className="text-right">Messages</span>
           <span className="text-right">Cost</span>
           <span className="text-right">Updated</span>
+          <span />
         </div>
         {filtered.length === 0 ? (
           <div className="p-8 text-center text-[13px] text-muted-foreground">
@@ -87,15 +171,16 @@ export default function SessionsPage() {
             {filtered.map((s) => (
               <div
                 key={s.id}
-                className="grid grid-cols-[1fr_1fr_100px_100px_100px_80px_100px] gap-2 px-4 py-2.5 items-center hover:bg-accent/50 transition-colors"
+                onClick={() => setSelectedSessionId(s.id)}
+                className="grid grid-cols-[1fr_1fr_100px_100px_100px_80px_100px_32px] gap-2 px-4 py-2.5 items-center hover:bg-accent/50 transition-colors cursor-pointer"
               >
                 <div className="flex items-center gap-2 min-w-0">
                   <div
                     className={`w-1.5 h-1.5 rounded-full shrink-0 ${
                       s.status === "active"
-                        ? "bg-success"
+                        ? "bg-green-500 animate-pulse"
                         : s.status === "idle"
-                          ? "bg-warning"
+                          ? "bg-yellow-500"
                           : "bg-muted-foreground/30"
                     }`}
                   />
@@ -121,11 +206,19 @@ export default function SessionsPage() {
                 <span className="text-[12px] text-right text-muted-foreground">
                   {timeAgo(s.updatedAt)}
                 </span>
+                <ChevronRight className="w-3.5 h-3.5 text-muted-foreground/40 ml-auto" />
               </div>
             ))}
           </div>
         )}
       </div>
+
+      {selectedSessionId && (
+        <MessageViewer
+          sessionId={selectedSessionId}
+          onClose={() => setSelectedSessionId(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/clawdash/src/components/agents/agent-status-cards.tsx
+++ b/apps/clawdash/src/components/agents/agent-status-cards.tsx
@@ -48,8 +48,8 @@ function QuickSendModal({ agent, onClose }: QuickSendModalProps) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="bg-card border border-border rounded-2xl w-full max-w-md flex flex-col gap-0 overflow-hidden">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50 sm:p-4">
+      <div className="bg-card border border-border rounded-t-2xl sm:rounded-2xl w-full sm:max-w-md flex flex-col gap-0 overflow-hidden">
         <div className="px-5 py-3.5 border-b border-border flex items-center justify-between">
           <div className="flex items-center gap-2.5">
             <span className="text-xl">{agent.emoji}</span>
@@ -72,7 +72,7 @@ function QuickSendModal({ agent, onClose }: QuickSendModalProps) {
         </div>
 
         {sent && response ? (
-          <div className="p-5 space-y-3">
+          <div className="p-5 space-y-3" style={{ paddingBottom: "max(1.25rem, env(safe-area-inset-bottom, 0px))" }}>
             <p className="text-[12px] text-muted-foreground font-medium uppercase tracking-wider">
               Response
             </p>
@@ -87,7 +87,7 @@ function QuickSendModal({ agent, onClose }: QuickSendModalProps) {
             </button>
           </div>
         ) : (
-          <div className="p-5 space-y-3">
+          <div className="p-5 space-y-3" style={{ paddingBottom: "max(1.25rem, env(safe-area-inset-bottom, 0px))" }}>
             <textarea
               value={message}
               onChange={(e) => setMessage(e.target.value)}
@@ -199,14 +199,14 @@ function AgentCard({
       <div className="flex gap-2 mt-auto pt-1">
         <button
           onClick={() => router.push(`/agents`)}
-          className="flex-1 h-8 rounded-lg border border-border text-[12px] hover:bg-accent transition-colors flex items-center justify-center gap-1.5"
+          className="flex-1 h-11 md:h-8 rounded-lg border border-border text-[12px] hover:bg-accent transition-colors flex items-center justify-center gap-1.5"
         >
           <MessageSquare className="w-3.5 h-3.5" />
           Chat
         </button>
         <button
           onClick={onQuickSend}
-          className="flex-1 h-8 rounded-lg bg-primary/10 text-primary text-[12px] hover:bg-primary/20 transition-colors flex items-center justify-center gap-1.5"
+          className="flex-1 h-11 md:h-8 rounded-lg bg-primary/10 text-primary text-[12px] hover:bg-primary/20 transition-colors flex items-center justify-center gap-1.5"
         >
           <Send className="w-3.5 h-3.5" />
           Quick Send

--- a/apps/clawdash/src/components/agents/agent-status-cards.tsx
+++ b/apps/clawdash/src/components/agents/agent-status-cards.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { AgentStatus } from "@/hooks/use-agents";
+import { useSendMessage } from "@/hooks/use-agents";
+import { timeAgo } from "@/lib/utils";
+import { Send, X, MessageSquare } from "lucide-react";
+
+interface QuickSendModalProps {
+  agent: AgentStatus;
+  onClose: () => void;
+}
+
+function QuickSendModal({ agent, onClose }: QuickSendModalProps) {
+  const [message, setMessage] = useState("");
+  const [sent, setSent] = useState(false);
+  const [response, setResponse] = useState<string | null>(null);
+  const { mutate: sendMessage, isPending } = useSendMessage();
+
+  function handleSend() {
+    const text = message.trim();
+    if (!text || isPending) return;
+
+    sendMessage(
+      {
+        message: text,
+        agentId: agent.id,
+        sessionKey: agent.sessionKey,
+      },
+      {
+        onSuccess: (data) => {
+          setSent(true);
+          if (typeof data.response === "string") {
+            setResponse(data.response);
+          } else if (data.error) {
+            setResponse(`Error: ${String(data.error)}`);
+          } else {
+            setResponse("Message sent.");
+          }
+        },
+        onError: (err) => {
+          setSent(true);
+          setResponse(`Failed: ${err.message}`);
+        },
+      }
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="bg-card border border-border rounded-2xl w-full max-w-md flex flex-col gap-0 overflow-hidden">
+        <div className="px-5 py-3.5 border-b border-border flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <span className="text-xl">{agent.emoji}</span>
+            <div>
+              <h3 className="text-[14px] font-semibold">
+                Quick message to {agent.name}
+              </h3>
+              <p className="text-[11px] text-muted-foreground capitalize">
+                {agent.status}
+                {agent.lastSeen ? ` · ${timeAgo(agent.lastSeen)}` : ""}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 rounded-lg hover:bg-accent flex items-center justify-center transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {sent && response ? (
+          <div className="p-5 space-y-3">
+            <p className="text-[12px] text-muted-foreground font-medium uppercase tracking-wider">
+              Response
+            </p>
+            <div className="bg-muted rounded-xl p-3.5 text-[13px] leading-relaxed max-h-48 overflow-y-auto whitespace-pre-wrap">
+              {response}
+            </div>
+            <button
+              onClick={onClose}
+              className="w-full h-9 rounded-xl bg-primary text-primary-foreground text-[13px] font-medium hover:bg-primary/90 transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        ) : (
+          <div className="p-5 space-y-3">
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSend();
+                }
+              }}
+              placeholder={`Message ${agent.name}…`}
+              rows={3}
+              autoFocus
+              className="w-full bg-input rounded-xl px-3.5 py-2.5 text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 resize-none"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={onClose}
+                className="flex-1 h-9 rounded-xl border border-border text-[13px] hover:bg-accent transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSend}
+                disabled={!message.trim() || isPending}
+                className="flex-1 h-9 rounded-xl bg-primary text-primary-foreground text-[13px] font-medium disabled:opacity-40 hover:bg-primary/90 transition-colors flex items-center justify-center gap-1.5"
+              >
+                {isPending ? (
+                  <span className="w-3.5 h-3.5 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full animate-spin" />
+                ) : (
+                  <Send className="w-3.5 h-3.5" />
+                )}
+                Send
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AgentCard({
+  agent,
+  onQuickSend,
+}: {
+  agent: AgentStatus;
+  onQuickSend: () => void;
+}) {
+  const router = useRouter();
+
+  const statusColor =
+    agent.status === "active"
+      ? "bg-green-500"
+      : agent.status === "idle"
+        ? "bg-yellow-500"
+        : "bg-muted-foreground/30";
+
+  const statusLabel =
+    agent.status === "active"
+      ? "Active"
+      : agent.status === "idle"
+        ? "Idle"
+        : "Offline";
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2.5">
+          <span className="text-2xl">{agent.emoji}</span>
+          <div>
+            <p className="text-[14px] font-semibold">{agent.name}</p>
+            <div className="flex items-center gap-1.5 mt-0.5">
+              <div
+                className={`w-1.5 h-1.5 rounded-full ${statusColor} ${
+                  agent.status === "active" ? "animate-pulse" : ""
+                }`}
+              />
+              <span className="text-[11px] text-muted-foreground">
+                {statusLabel}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-1 text-[12px] text-muted-foreground">
+        <div className="flex items-center justify-between">
+          <span>Last seen</span>
+          <span className="text-foreground/80">
+            {agent.lastSeen ? timeAgo(agent.lastSeen) : "Never"}
+          </span>
+        </div>
+        {agent.model && (
+          <div className="flex items-center justify-between">
+            <span>Model</span>
+            <span className="text-foreground/80 font-mono text-[11px] truncate max-w-[120px]">
+              {agent.model.split("/").pop() ?? agent.model}
+            </span>
+          </div>
+        )}
+        {agent.messageCount !== undefined && (
+          <div className="flex items-center justify-between">
+            <span>Messages</span>
+            <span className="text-foreground/80">{agent.messageCount}</span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-2 mt-auto pt-1">
+        <button
+          onClick={() => router.push(`/agents`)}
+          className="flex-1 h-8 rounded-lg border border-border text-[12px] hover:bg-accent transition-colors flex items-center justify-center gap-1.5"
+        >
+          <MessageSquare className="w-3.5 h-3.5" />
+          Chat
+        </button>
+        <button
+          onClick={onQuickSend}
+          className="flex-1 h-8 rounded-lg bg-primary/10 text-primary text-[12px] hover:bg-primary/20 transition-colors flex items-center justify-center gap-1.5"
+        >
+          <Send className="w-3.5 h-3.5" />
+          Quick Send
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function AgentStatusCards({ agents }: { agents: AgentStatus[] }) {
+  const [quickSendAgent, setQuickSendAgent] = useState<AgentStatus | null>(
+    null
+  );
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[13px] font-semibold">Agent Status</span>
+        <span className="text-[11px] text-muted-foreground">
+          {agents.filter((a) => a.status === "active").length} active
+        </span>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        {agents.map((agent) => (
+          <AgentCard
+            key={agent.id}
+            agent={agent}
+            onQuickSend={() => setQuickSendAgent(agent)}
+          />
+        ))}
+      </div>
+
+      {quickSendAgent && (
+        <QuickSendModal
+          agent={quickSendAgent}
+          onClose={() => setQuickSendAgent(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/clawdash/src/components/app-sidebar.tsx
+++ b/apps/clawdash/src/components/app-sidebar.tsx
@@ -14,9 +14,16 @@ import {
   ScrollText,
   Clock,
   Settings,
+  Bot,
 } from "lucide-react";
 
 const navSections = [
+  {
+    label: "Control",
+    items: [
+      { href: "/agents", label: "Agents", icon: Bot },
+    ],
+  },
   {
     label: "Monitor",
     items: [

--- a/apps/clawdash/src/components/app-sidebar.tsx
+++ b/apps/clawdash/src/components/app-sidebar.tsx
@@ -57,7 +57,7 @@ const bottomTabs = [
   { href: "/agents", label: "Agents", icon: Bot },
   { href: "/sessions", label: "Sessions", icon: MessagesSquare },
   { href: "/costs", label: "Costs", icon: DollarSign },
-  { href: "/logs", label: "Logs", icon: ScrollText },
+  { href: "/cron", label: "Cron", icon: Clock },
 ];
 
 export function AppSidebar() {

--- a/apps/clawdash/src/components/app-sidebar.tsx
+++ b/apps/clawdash/src/components/app-sidebar.tsx
@@ -51,62 +51,108 @@ const navSections = [
   },
 ];
 
+// Bottom tabs: max 5 — the most essential sections
+const bottomTabs = [
+  { href: "/", label: "Overview", icon: LayoutDashboard },
+  { href: "/agents", label: "Agents", icon: Bot },
+  { href: "/sessions", label: "Sessions", icon: MessagesSquare },
+  { href: "/costs", label: "Costs", icon: DollarSign },
+  { href: "/logs", label: "Logs", icon: ScrollText },
+];
+
 export function AppSidebar() {
   const pathname = usePathname();
 
   return (
-    <aside className="w-60 shrink-0 h-full border-r border-sidebar-border bg-sidebar backdrop-blur-xl flex flex-col">
-      <div className="h-14 flex items-center px-5 border-b border-sidebar-border">
-        <div className="flex items-center gap-2.5">
-          <div className="w-7 h-7 rounded-lg bg-primary flex items-center justify-center">
-            <span className="text-primary-foreground text-xs font-bold">
-              🦞
+    <>
+      {/* Desktop sidebar — hidden on mobile */}
+      <aside className="hidden md:flex w-60 shrink-0 h-full border-r border-sidebar-border bg-sidebar backdrop-blur-xl flex-col">
+        <div className="h-14 flex items-center px-5 border-b border-sidebar-border">
+          <div className="flex items-center gap-2.5">
+            <div className="w-7 h-7 rounded-lg bg-primary flex items-center justify-center">
+              <span className="text-primary-foreground text-xs font-bold">
+                🦞
+              </span>
+            </div>
+            <span className="text-sm font-semibold tracking-tight text-sidebar-foreground">
+              ClawDash
             </span>
           </div>
-          <span className="text-sm font-semibold tracking-tight text-sidebar-foreground">
-            ClawDash
-          </span>
         </div>
-      </div>
 
-      <nav className="flex-1 overflow-y-auto px-3 py-3 space-y-5">
-        {navSections.map((section) => (
-          <div key={section.label}>
-            <p className="px-2 mb-1.5 text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
-              {section.label}
-            </p>
-            <div className="space-y-0.5">
-              {section.items.map((item) => {
-                const isActive =
-                  pathname === item.href ||
-                  (item.href !== "/" && pathname.startsWith(item.href));
-                return (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className={cn(
-                      "flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg text-[13px] transition-colors duration-150",
-                      isActive
-                        ? "bg-sidebar-primary text-sidebar-primary-foreground font-medium"
-                        : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-                    )}
-                  >
-                    <item.icon className="w-4 h-4 shrink-0" />
-                    {item.label}
-                  </Link>
-                );
-              })}
+        <nav className="flex-1 overflow-y-auto px-3 py-3 space-y-5">
+          {navSections.map((section) => (
+            <div key={section.label}>
+              <p className="px-2 mb-1.5 text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
+                {section.label}
+              </p>
+              <div className="space-y-0.5">
+                {section.items.map((item) => {
+                  const isActive =
+                    pathname === item.href ||
+                    (item.href !== "/" && pathname.startsWith(item.href));
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className={cn(
+                        "flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg text-[13px] transition-colors duration-150",
+                        isActive
+                          ? "bg-sidebar-primary text-sidebar-primary-foreground font-medium"
+                          : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                      )}
+                    >
+                      <item.icon className="w-4 h-4 shrink-0" />
+                      {item.label}
+                    </Link>
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        ))}
-      </nav>
+          ))}
+        </nav>
 
-      <div className="px-4 py-3 border-t border-sidebar-border">
-        <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-          <div className="w-1.5 h-1.5 rounded-full bg-success animate-pulse" />
-          Gateway connected
+        <div className="px-4 py-3 border-t border-sidebar-border">
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <div className="w-1.5 h-1.5 rounded-full bg-success animate-pulse" />
+            Gateway connected
+          </div>
         </div>
-      </div>
-    </aside>
+      </aside>
+
+      {/* Mobile bottom tab bar — shown only on mobile */}
+      <nav
+        className="md:hidden fixed bottom-0 inset-x-0 z-50 bg-sidebar border-t border-sidebar-border flex items-stretch pb-safe"
+        style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
+      >
+        {bottomTabs.map((tab) => {
+          const isActive =
+            pathname === tab.href ||
+            (tab.href !== "/" && pathname.startsWith(tab.href));
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              className={cn(
+                "flex-1 flex flex-col items-center justify-center gap-1 py-2 min-h-[56px] transition-colors",
+                isActive
+                  ? "text-primary"
+                  : "text-sidebar-foreground/50 hover:text-sidebar-foreground"
+              )}
+            >
+              <tab.icon
+                className={cn(
+                  "w-5 h-5 shrink-0",
+                  isActive ? "text-primary" : ""
+                )}
+              />
+              <span className="text-[10px] font-medium leading-none">
+                {tab.label}
+              </span>
+            </Link>
+          );
+        })}
+      </nav>
+    </>
   );
 }

--- a/apps/clawdash/src/hooks/use-agents.ts
+++ b/apps/clawdash/src/hooks/use-agents.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useQuery, useMutation } from "@tanstack/react-query";
+import type { SessionInfo } from "@/hooks/use-sessions";
+
+export interface AgentMeta {
+  id: string;
+  name: string;
+  emoji: string;
+}
+
+export interface AgentStatus extends AgentMeta {
+  status: "active" | "idle" | "offline";
+  lastSeen?: string;
+  sessionKey?: string;
+  model?: string;
+  messageCount?: number;
+}
+
+export function useAgents() {
+  return useQuery<{ agents: AgentMeta[] }>({
+    queryKey: ["agents"],
+    queryFn: async () => {
+      const res = await fetch("/api/agents");
+      return res.json();
+    },
+    staleTime: 60_000,
+  });
+}
+
+export function useAgentStatuses(sessions: SessionInfo[]) {
+  const KNOWN_AGENTS: AgentMeta[] = [
+    { id: "main", name: "Ash", emoji: "🔥" },
+    { id: "ocean", name: "Ocean", emoji: "🌊" },
+    { id: "skylar", name: "Skylar", emoji: "⚡" },
+    { id: "coral", name: "Coral", emoji: "🪸" },
+    { id: "arctic", name: "Arctic", emoji: "🧊" },
+  ];
+
+  return KNOWN_AGENTS.map((agent): AgentStatus => {
+    // Match sessions by agent id in the session key/channel
+    const agentSessions = sessions.filter(
+      (s) =>
+        s.channel?.toLowerCase().includes(agent.id) ||
+        s.id.toLowerCase().includes(agent.id)
+    );
+
+    const latestSession = agentSessions.sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    )[0];
+
+    if (!latestSession) {
+      return { ...agent, status: "offline" };
+    }
+
+    const lastSeenMs =
+      Date.now() - new Date(latestSession.updatedAt).getTime();
+    const isActive = latestSession.status === "active";
+    const isRecent = lastSeenMs < 5 * 60 * 1000; // 5 min
+
+    return {
+      ...agent,
+      status: isActive ? "active" : isRecent ? "idle" : "offline",
+      lastSeen: latestSession.updatedAt,
+      sessionKey: latestSession.id,
+      model: latestSession.model,
+      messageCount: latestSession.messageCount,
+    };
+  });
+}
+
+export interface SendMessagePayload {
+  message: string;
+  agentId?: string;
+  sessionKey?: string;
+}
+
+export interface SendMessageResponse {
+  ok?: boolean;
+  response?: string;
+  error?: string;
+  [key: string]: unknown;
+}
+
+export function useSendMessage() {
+  return useMutation<SendMessageResponse, Error, SendMessagePayload>({
+    mutationFn: async (payload) => {
+      const res = await fetch("/api/message", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      return res.json();
+    },
+  });
+}

--- a/apps/clawdash/src/hooks/use-session-messages.ts
+++ b/apps/clawdash/src/hooks/use-session-messages.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+export interface SessionMessage {
+  id: string;
+  role: "user" | "assistant" | "tool";
+  content: string;
+  timestamp: string;
+}
+
+export function useSessionMessages(
+  sessionId: string | null,
+  agentId?: string,
+  limit = 50
+) {
+  return useQuery<{ messages: SessionMessage[] }>({
+    queryKey: ["session-messages", sessionId, agentId, limit],
+    queryFn: async () => {
+      const params = new URLSearchParams({ sessionId: sessionId! });
+      if (agentId) params.set("agentId", agentId);
+      params.set("limit", String(limit));
+      const res = await fetch(`/api/session-messages?${params}`);
+      return res.json();
+    },
+    enabled: !!sessionId,
+    staleTime: 10_000,
+  });
+}

--- a/apps/clawdash/src/lib/openclaw.ts
+++ b/apps/clawdash/src/lib/openclaw.ts
@@ -44,6 +44,83 @@ export interface SessionInfo {
   channel?: string;
 }
 
+interface JournalEntry {
+  type: string;
+  id?: string;
+  version?: number;
+  timestamp?: string;
+  provider?: string;
+  modelId?: string;
+  customType?: string;
+  message?: {
+    role?: string;
+    content?: unknown;
+    timestamp?: number;
+  };
+}
+
+async function parseJsonlSession(
+  sessionId: string,
+  filePath: string,
+  fileStat: { mtimeMs: number }
+): Promise<SessionInfo | null> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const lines = raw.trim().split("\n").filter(Boolean);
+
+    let model = "unknown";
+    let createdAt: string | null = null;
+    let messageCount = 0;
+
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as JournalEntry;
+        if (entry.type === "session" && entry.timestamp) {
+          createdAt = entry.timestamp;
+        }
+        if (
+          (entry.type === "model_change" ||
+            entry.customType === "model-snapshot") &&
+          entry.modelId
+        ) {
+          model = `${entry.provider ?? "anthropic"}/${entry.modelId}`;
+        }
+        if (
+          entry.type === "message" &&
+          entry.message?.role === "user"
+        ) {
+          messageCount++;
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+
+    const updatedAt = new Date(fileStat.mtimeMs).toISOString();
+    const ageMs = Date.now() - fileStat.mtimeMs;
+    const status: SessionInfo["status"] =
+      ageMs < 2 * 60 * 1000
+        ? "active"
+        : ageMs < 30 * 60 * 1000
+          ? "idle"
+          : "closed";
+
+    return {
+      id: sessionId,
+      model,
+      status,
+      tokensIn: 0,
+      tokensOut: 0,
+      costCents: 0,
+      messageCount,
+      createdAt: createdAt ?? updatedAt,
+      updatedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export async function listSessions(): Promise<SessionInfo[]> {
   const sessionsDir = join(
     getOpenClawDir(),
@@ -57,25 +134,40 @@ export async function listSessions(): Promise<SessionInfo[]> {
   const sessions: SessionInfo[] = [];
 
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const metaPath = join(sessionsDir, entry.name, "metadata.json");
-    try {
-      const raw = await readFile(metaPath, "utf-8");
-      const meta = JSON.parse(raw);
-      sessions.push({
-        id: entry.name,
-        model: meta.model || "unknown",
-        status: meta.status || "idle",
-        tokensIn: meta.tokensIn || meta.inputTokens || 0,
-        tokensOut: meta.tokensOut || meta.outputTokens || 0,
-        costCents: meta.costCents || meta.cost || 0,
-        messageCount: meta.messageCount || meta.messages?.length || 0,
-        createdAt: meta.createdAt || meta.created || new Date().toISOString(),
-        updatedAt: meta.updatedAt || meta.updated || new Date().toISOString(),
-        channel: meta.channel,
-      });
-    } catch {
-      // skip unreadable sessions
+    // Support both JSONL files and subdirectory metadata.json
+    if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      const sessionId = entry.name.replace(/\.jsonl$/, "");
+      // Skip reset files
+      if (sessionId.includes(".reset.")) continue;
+      const filePath = join(sessionsDir, entry.name);
+      try {
+        const fileStat = await stat(filePath);
+        const session = await parseJsonlSession(sessionId, filePath, fileStat);
+        if (session) sessions.push(session);
+      } catch {
+        // skip
+      }
+    } else if (entry.isDirectory()) {
+      const metaPath = join(sessionsDir, entry.name, "metadata.json");
+      try {
+        const raw = await readFile(metaPath, "utf-8");
+        const meta = JSON.parse(raw);
+        sessions.push({
+          id: entry.name,
+          model: meta.model || "unknown",
+          status: meta.status || "idle",
+          tokensIn: meta.tokensIn || meta.inputTokens || 0,
+          tokensOut: meta.tokensOut || meta.outputTokens || 0,
+          costCents: meta.costCents || meta.cost || 0,
+          messageCount: meta.messageCount || meta.messages?.length || 0,
+          createdAt: meta.createdAt || meta.created || new Date().toISOString(),
+          updatedAt:
+            meta.updatedAt || meta.updated || new Date().toISOString(),
+          channel: meta.channel,
+        });
+      } catch {
+        // skip unreadable sessions
+      }
     }
   }
 

--- a/apps/clawdash/src/lib/openclaw.ts
+++ b/apps/clawdash/src/lib/openclaw.ts
@@ -381,6 +381,23 @@ export async function listCronJobs(): Promise<CronJob[]> {
   }
 }
 
+export async function toggleCronJob(id: string, enabled: boolean): Promise<boolean> {
+  const cronPath = join(getOpenClawDir(), "cron", "jobs.json");
+  try {
+    const raw = await readFile(cronPath, "utf-8");
+    const data = JSON.parse(raw);
+    const jobs: CronJob[] = Array.isArray(data) ? data : data.jobs || [];
+    const job = jobs.find((j) => j.id === id);
+    if (!job) return false;
+    job.enabled = enabled;
+    const updated = Array.isArray(data) ? jobs : { ...data, jobs };
+    await writeFile(cronPath, JSON.stringify(updated, null, 2), "utf-8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function readOpenClawConfig(): Promise<Record<string, unknown> | null> {
   const configPath = join(getOpenClawDir(), "openclaw.json");
   try {


### PR DESCRIPTION
## Changes

- Replaced "Logs" with "Cron" in the mobile bottom tab bar
- Added `toggleCronJob` to `@/lib/openclaw` to fix pre-existing TypeScript error
- Also included untracked cron API routes (`/api/crons/[id]/toggle` and `/api/crons/[id]/run`) that were already on the branch

The desktop sidebar already had Cron Jobs in the System section. This PR ensures Cron is reachable from mobile bottom nav too.

- [ ] Tested on mobile viewport (375px)