### PR TITLE
feat(ci): add GitHub Actions CI — type check + lint on every PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## What does this PR do?
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Docs / config
+
+## Checklist
+- [ ] Tested locally
+- [ ] Tested on mobile viewport (375px) — for any UI changes
+- [ ] No hardcoded IPs, tokens, or secrets
+- [ ] Branch is based off `allen/os`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [allen/os, main]
+  push:
+    branches: [allen/os]
+
+jobs:
+  ci:
+    name: Type Check & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '23'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm check-types --filter='!apps/paperclip'
+
+      - name: Lint
+        run: pnpm lint --filter='!apps/paperclip'


### PR DESCRIPTION
## What does this PR do?

Adds GitHub Actions CI workflow that runs on every PR to `allen/os`. Validates the codebase with type checking and linting before merge.

**What runs:**
- `pnpm check-types` — catches TypeScript errors
- `pnpm lint` — catches code quality issues
- Both exclude `apps/paperclip` (nested workspace complexity)

**Also adds** `.github/PULL_REQUEST_TEMPLATE.md` for consistent PR descriptions.

## Type of change
- [x] Docs / config

## Checklist
- [x] Tested locally
- [x] No hardcoded IPs, tokens, or secrets
- [x] Branch is based off `allen/os`