### PR TITLE
feat(store): Blueprint App Store — registry + blueprint install command

### DIFF
--- a/packages/blueprint-cli/src/commands/install.ts
+++ b/packages/blueprint-cli/src/commands/install.ts
@@ -1,0 +1,202 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import kleur from "kleur";
+import { findMonorepoRoot } from "../utils/detect-root.js";
+
+const REGISTRY_REMOTE_URL =
+  "https://raw.githubusercontent.com/allenchuang/blueprint/allen/os/registry/index.json";
+
+interface RegistryPackage {
+  id: string;
+  name: string;
+  description: string;
+  type: string;
+  version: string;
+  author: string;
+  tags: string[];
+  port: number;
+  icon: string;
+  color: string;
+}
+
+interface Registry {
+  version: string;
+  updatedAt: string;
+  packages: RegistryPackage[];
+}
+
+async function loadRegistry(monorepoRoot: string): Promise<Registry> {
+  const localPath = join(monorepoRoot, "registry", "index.json");
+
+  if (existsSync(localPath)) {
+    const raw = readFileSync(localPath, "utf-8");
+    return JSON.parse(raw) as Registry;
+  }
+
+  // Fall back to remote
+  const res = await fetch(REGISTRY_REMOTE_URL);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch remote registry: HTTP ${res.status}`);
+  }
+  return (await res.json()) as Registry;
+}
+
+function addToAppsRegistry(
+  monorepoRoot: string,
+  pkg: RegistryPackage,
+): void {
+  const registryPath = join(
+    monorepoRoot,
+    "packages",
+    "app-config",
+    "src",
+    "apps-registry.ts",
+  );
+
+  if (!existsSync(registryPath)) {
+    console.log(kleur.yellow("  ⚠ Could not find apps-registry.ts — skipping registry update."));
+    return;
+  }
+
+  const content = readFileSync(registryPath, "utf-8");
+
+  // Check if already registered
+  if (content.includes(`id: "${pkg.id}"`)) {
+    console.log(kleur.dim(`  ↳ ${pkg.name} already in apps-registry.ts`));
+    return;
+  }
+
+  const newEntry = `  {
+    id: "${pkg.id}",
+    name: "${pkg.name}",
+    port: ${pkg.port},
+    description: "${pkg.description}",
+    icon: "${pkg.icon}",
+    color: "${pkg.color}",
+    subdomain: "${pkg.id}",
+    openMaximized: true,
+    access: "public",
+    type: "nextjs",
+  },`;
+
+  // Insert before the closing bracket of the array
+  const updated = content.replace(
+    /^];$/m,
+    `${newEntry}\n];`,
+  );
+
+  writeFileSync(registryPath, updated, "utf-8");
+  console.log(kleur.dim(`  ↳ Added ${pkg.name} to apps-registry.ts`));
+}
+
+function scaffoldAppStub(monorepoRoot: string, pkg: RegistryPackage): void {
+  const appDir = join(monorepoRoot, "apps", pkg.id);
+
+  if (existsSync(appDir)) {
+    console.log(kleur.dim(`  ↳ apps/${pkg.id}/ already exists — skipping scaffold`));
+    return;
+  }
+
+  mkdirSync(appDir, { recursive: true });
+
+  const packageJson = {
+    name: `@repo/${pkg.id}`,
+    version: "0.1.0",
+    private: true,
+    description: pkg.description,
+    scripts: {
+      dev: `next dev --port ${pkg.port}`,
+      build: "next build",
+      start: `next start --port ${pkg.port}`,
+      lint: "next lint",
+    },
+    dependencies: {
+      next: "15.3.1",
+      react: "^19.0.0",
+      "react-dom": "^19.0.0",
+    },
+    devDependencies: {
+      "@repo/typescript-config": "workspace:*",
+      "@repo/eslint-config": "workspace:*",
+      "@types/node": "^22.0.0",
+      "@types/react": "^19.0.0",
+      "@types/react-dom": "^19.0.0",
+      typescript: "^5.8.0",
+    },
+  };
+
+  writeFileSync(
+    join(appDir, "package.json"),
+    JSON.stringify(packageJson, null, 2) + "\n",
+    "utf-8",
+  );
+
+  const readme = `# ${pkg.name}
+
+> ${pkg.description}
+
+**Status:** 🚧 Coming soon — ${pkg.name} will be available here.
+
+This app was scaffolded via \`blueprint install ${pkg.id}\`.
+Full implementation is on the roadmap for Phase 2.
+
+## Running
+
+\`\`\`bash
+pnpm dev:${pkg.id}
+\`\`\`
+
+Available at \`http://localhost:${pkg.port}\`.
+`;
+
+  writeFileSync(join(appDir, "README.md"), readme, "utf-8");
+
+  console.log(kleur.dim(`  ↳ Scaffolded apps/${pkg.id}/`));
+}
+
+export async function installCommand(packageId: string): Promise<void> {
+  const root = findMonorepoRoot();
+
+  if (!root) {
+    console.error(kleur.red("✖ Could not find a Blueprint monorepo root."));
+    console.error(
+      kleur.dim("  Make sure you are inside a Blueprint project directory."),
+    );
+    process.exit(1);
+  }
+
+  let registry: Registry;
+
+  try {
+    registry = await loadRegistry(root);
+  } catch (err) {
+    console.error(kleur.red("✖ Failed to load registry."));
+    console.error(kleur.dim(`  ${err instanceof Error ? err.message : String(err)}`));
+    process.exit(1);
+  }
+
+  const pkg = registry.packages.find((p) => p.id === packageId);
+
+  if (!pkg) {
+    console.error(kleur.red(`✖ Package "${packageId}" not found in registry.`));
+    console.error(
+      kleur.dim(
+        `  Available: ${registry.packages.map((p) => p.id).join(", ")}`,
+      ),
+    );
+    console.error(kleur.dim("  Run `blueprint list` to see all packages."));
+    process.exit(1);
+  }
+
+  console.log(
+    `\n${kleur.cyan("blueprint")} ${kleur.bold("install")} ${kleur.green(pkg.id)}\n`,
+  );
+  console.log(`Installing ${kleur.bold(pkg.name)} (${pkg.version})...`);
+
+  scaffoldAppStub(root, pkg);
+  addToAppsRegistry(root, pkg);
+
+  console.log(
+    `\n✅ ${kleur.bold(pkg.name)} installed. Run ${kleur.cyan(`pnpm dev:${pkg.id}`)} to start it.\n`,
+  );
+}

--- a/packages/blueprint-cli/src/commands/list.ts
+++ b/packages/blueprint-cli/src/commands/list.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import kleur from "kleur";
+import { findMonorepoRoot } from "../utils/detect-root.js";
+
+const REGISTRY_REMOTE_URL =
+  "https://raw.githubusercontent.com/allenchuang/blueprint/allen/os/registry/index.json";
+
+interface RegistryPackage {
+  id: string;
+  name: string;
+  description: string;
+  type: string;
+  version: string;
+  author: string;
+  tags: string[];
+  port: number;
+  icon: string;
+  color: string;
+}
+
+interface Registry {
+  version: string;
+  updatedAt: string;
+  packages: RegistryPackage[];
+}
+
+async function loadRegistry(monorepoRoot: string | null): Promise<Registry> {
+  if (monorepoRoot) {
+    const localPath = join(monorepoRoot, "registry", "index.json");
+    if (existsSync(localPath)) {
+      const raw = readFileSync(localPath, "utf-8");
+      return JSON.parse(raw) as Registry;
+    }
+  }
+
+  // Fall back to remote
+  const res = await fetch(REGISTRY_REMOTE_URL);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch remote registry: HTTP ${res.status}`);
+  }
+  return (await res.json()) as Registry;
+}
+
+export async function listCommand(): Promise<void> {
+  const root = findMonorepoRoot();
+
+  let registry: Registry;
+
+  try {
+    registry = await loadRegistry(root);
+  } catch (err) {
+    console.error(kleur.red("✖ Failed to load registry."));
+    console.error(
+      kleur.dim(`  ${err instanceof Error ? err.message : String(err)}`),
+    );
+    process.exit(1);
+  }
+
+  const source = root && existsSync(join(root, "registry", "index.json"))
+    ? kleur.dim("(local registry)")
+    : kleur.dim("(remote registry)");
+
+  console.log(
+    `\n${kleur.cyan("Blueprint App Store")} ${source}\n`,
+  );
+
+  console.log(
+    `${kleur.bold(String(registry.packages.length))} package${registry.packages.length === 1 ? "" : "s"} available:\n`,
+  );
+
+  for (const pkg of registry.packages) {
+    const tags = pkg.tags.map((t) => kleur.dim(`#${t}`)).join(" ");
+    console.log(
+      `  ${kleur.green(kleur.bold(pkg.id.padEnd(12)))} ${kleur.white(pkg.name)} ${kleur.dim(`v${pkg.version}`)}`,
+    );
+    console.log(`  ${kleur.dim(" ".repeat(12))} ${pkg.description}`);
+    console.log(`  ${kleur.dim(" ".repeat(12))} ${tags}`);
+    console.log();
+  }
+
+  console.log(
+    `${kleur.dim("Run")} ${kleur.cyan("blueprint install <id>")} ${kleur.dim("to install a package.")}\n`,
+  );
+}

--- a/packages/blueprint-cli/src/index.ts
+++ b/packages/blueprint-cli/src/index.ts
@@ -8,6 +8,8 @@ import prompts from "prompts";
 import { newCommand } from "./commands/new.js";
 import type { NewCommandOptions } from "./commands/new.js";
 import { runCommand, listProxyCommands } from "./commands/run.js";
+import { installCommand } from "./commands/install.js";
+import { listCommand } from "./commands/list.js";
 import { printLogo } from "./utils/logo.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -62,6 +64,20 @@ program
     }
 
     await newCommand(projectName!, opts);
+  });
+
+program
+  .command("install <package-id>")
+  .description("Install a package from the Blueprint App Store")
+  .action(async (packageId: string) => {
+    await installCommand(packageId);
+  });
+
+program
+  .command("list")
+  .description("List all available packages in the Blueprint App Store")
+  .action(async () => {
+    await listCommand();
   });
 
 const proxyCommands = listProxyCommands();

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,0 +1,101 @@
+# Blueprint App Store — Registry
+
+This directory is the **source of truth** for all Blueprint apps available via `blueprint install`.
+
+## Structure
+
+```
+registry/
+├── index.json           ← Master package list (auto-read by CLI)
+├── README.md            ← This file
+└── packages/
+    ├── crm/
+    │   ├── manifest.json
+    │   └── README.md
+    ├── pulse/
+    │   ├── manifest.json
+    │   └── README.md
+    └── support/
+        ├── manifest.json
+        └── README.md
+```
+
+## Installing a Package
+
+```bash
+blueprint install crm
+blueprint install pulse
+blueprint install support
+```
+
+To see all available packages:
+
+```bash
+blueprint list
+```
+
+## How to Contribute a Package
+
+1. **Fork** the Blueprint repo and create a branch: `registry/your-package-name`
+
+2. **Create the package directory:**
+
+   ```
+   registry/packages/your-package/
+   ├── manifest.json
+   └── README.md
+   ```
+
+3. **Write `manifest.json`** following this schema:
+
+   ```json
+   {
+     "id": "your-package",
+     "name": "Your Package Name",
+     "version": "0.1.0",
+     "type": "app",
+     "description": "What it does in one sentence.",
+     "port": 3010,
+     "appType": "nextjs",
+     "icon": "icon-name",
+     "color": "teal",
+     "subdomain": "your-package",
+     "envVars": ["REQUIRED_ENV_VAR"],
+     "dependencies": [],
+     "postInstall": "pnpm install"
+   }
+   ```
+
+   **Port guidelines:** Use 3005–3099 for community apps (3005–3007 are first-party).
+
+4. **Add your entry to `registry/index.json`** in the `packages` array.
+
+5. **Write a clear `README.md`** explaining what the app does, how to configure it, and any env vars needed.
+
+6. **Open a PR** targeting `allen/os` with the title: `registry(your-package): add <Package Name>`.
+
+## Package Manifest Fields
+
+| Field          | Required | Description                                      |
+|----------------|----------|--------------------------------------------------|
+| `id`           | ✅       | Unique kebab-case identifier                     |
+| `name`         | ✅       | Human-readable name                              |
+| `version`      | ✅       | SemVer string                                    |
+| `type`         | ✅       | Always `"app"` for now                           |
+| `description`  | ✅       | One-line description                             |
+| `port`         | ✅       | Local dev port (must be unique)                  |
+| `appType`      | ✅       | `nextjs` \| `fastify` \| `standalone`            |
+| `icon`         | ✅       | Lucide icon name                                 |
+| `color`        | ✅       | Tailwind color name                              |
+| `subdomain`    | ✅       | Caddy subdomain for production                   |
+| `envVars`      |          | Required env variable names (array of strings)   |
+| `dependencies` |          | Other package IDs this depends on                |
+| `postInstall`  |          | Shell command to run after scaffolding           |
+
+## First-Party Packages
+
+| Package           | Port | Description                                  |
+|-------------------|------|----------------------------------------------|
+| `blueprint-crm`   | 3005 | Customer pipeline with agent-powered follow-ups |
+| `blueprint-pulse` | 3006 | CEO-view KPI dashboard                       |
+| `blueprint-support`| 3007 | AI-first support inbox                      |

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0.0",
+  "updatedAt": "2026-03-28T00:00:00Z",
+  "packages": [
+    {
+      "id": "crm",
+      "name": "Blueprint CRM",
+      "description": "Lightweight customer pipeline — track leads, trials, and paid users. Agent-powered follow-ups.",
+      "type": "app",
+      "version": "0.1.0",
+      "author": "blueprint",
+      "tags": ["crm", "sales", "customers"],
+      "port": 3005,
+      "icon": "users",
+      "color": "teal"
+    },
+    {
+      "id": "pulse",
+      "name": "Blueprint Pulse",
+      "description": "Unified KPI dashboard — MRR, active users, agent activity, cost per run. The CEO view.",
+      "type": "app",
+      "version": "0.1.0",
+      "author": "blueprint",
+      "tags": ["analytics", "metrics", "dashboard"],
+      "port": 3006,
+      "icon": "bar-chart",
+      "color": "violet"
+    },
+    {
+      "id": "support",
+      "name": "Blueprint Support",
+      "description": "AI-first customer support inbox. Agents handle tier-1, escalate to you. Syncs with docs.",
+      "type": "app",
+      "version": "0.1.0",
+      "author": "blueprint",
+      "tags": ["support", "customers", "inbox"],
+      "port": 3007,
+      "icon": "message-circle",
+      "color": "amber"
+    }
+  ]
+}

--- a/registry/packages/crm/README.md
+++ b/registry/packages/crm/README.md
@@ -1,0 +1,40 @@
+# Blueprint CRM
+
+**Port:** 3005 | **Color:** Teal | **Icon:** users
+
+Lightweight customer relationship management built for indie hackers and small teams. Track leads through your pipeline, manage trials, and convert to paid — with AI agents handling follow-ups automatically.
+
+## Features
+
+- **Pipeline view** — Kanban board for leads → trials → paid
+- **Agent follow-ups** — AI automatically drafts and schedules outreach
+- **Customer profiles** — Full history, notes, and activity timeline
+- **MRR tracking** — See revenue impact as deals move through stages
+
+## Install
+
+```bash
+blueprint install crm
+```
+
+## Configuration
+
+No env vars required to get started. Optional integrations:
+
+| Variable              | Description                          |
+|-----------------------|--------------------------------------|
+| `CRM_SMTP_HOST`       | SMTP server for agent email sending  |
+| `CRM_SMTP_USER`       | SMTP username                        |
+| `CRM_SMTP_PASS`       | SMTP password                        |
+
+## Running
+
+```bash
+pnpm dev:crm
+```
+
+App available at `http://localhost:3005`.
+
+## Status
+
+🚧 **Coming Soon** — This app is scaffolded and registered. Full implementation arriving in Phase 2.

--- a/registry/packages/crm/manifest.json
+++ b/registry/packages/crm/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "crm",
+  "name": "Blueprint CRM",
+  "version": "0.1.0",
+  "type": "app",
+  "description": "Lightweight customer pipeline — track leads, trials, and paid users. Agent-powered follow-ups.",
+  "port": 3005,
+  "appType": "nextjs",
+  "icon": "users",
+  "color": "teal",
+  "subdomain": "crm",
+  "envVars": [],
+  "dependencies": [],
+  "postInstall": "pnpm install"
+}

--- a/registry/packages/pulse/README.md
+++ b/registry/packages/pulse/README.md
@@ -1,0 +1,39 @@
+# Blueprint Pulse
+
+**Port:** 3006 | **Color:** Violet | **Icon:** bar-chart
+
+The CEO view. One dashboard to see everything that matters — MRR, active users, agent activity, and AI cost per run. Built for founders who need the full picture at a glance.
+
+## Features
+
+- **MRR & ARR** — Revenue trends with growth rate indicators
+- **Active users** — DAU/MAU with retention cohort breakdowns
+- **Agent activity** — Runs, success rate, errors, and cost per invocation
+- **Cost per run** — Track AI spend across all your agents in real-time
+- **Custom widgets** — Add your own KPIs via config
+
+## Install
+
+```bash
+blueprint install pulse
+```
+
+## Configuration
+
+No env vars required. Pulls from your Blueprint server API automatically.
+
+| Variable               | Description                          |
+|------------------------|--------------------------------------|
+| `PULSE_ANALYTICS_KEY`  | Optional: third-party analytics sink |
+
+## Running
+
+```bash
+pnpm dev:pulse
+```
+
+App available at `http://localhost:3006`.
+
+## Status
+
+🚧 **Coming Soon** — This app is scaffolded and registered. Full implementation arriving in Phase 2.

--- a/registry/packages/pulse/manifest.json
+++ b/registry/packages/pulse/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "pulse",
+  "name": "Blueprint Pulse",
+  "version": "0.1.0",
+  "type": "app",
+  "description": "Unified KPI dashboard — MRR, active users, agent activity, cost per run. The CEO view.",
+  "port": 3006,
+  "appType": "nextjs",
+  "icon": "bar-chart",
+  "color": "violet",
+  "subdomain": "pulse",
+  "envVars": [],
+  "dependencies": [],
+  "postInstall": "pnpm install"
+}

--- a/registry/packages/support/README.md
+++ b/registry/packages/support/README.md
@@ -1,0 +1,39 @@
+# Blueprint Support
+
+**Port:** 3007 | **Color:** Amber | **Icon:** message-circle
+
+AI-first customer support inbox. Agents handle tier-1 questions automatically by referencing your docs — and escalate to you only when they need a human decision. Never lose a support ticket again.
+
+## Features
+
+- **AI triage** — Agents classify, prioritize, and route incoming tickets
+- **Auto-responses** — Tier-1 questions answered instantly from your docs
+- **Smart escalation** — Unclear or high-stakes issues surface to your queue
+- **Docs sync** — Ingests your Mintlify docs as agent knowledge base
+- **Shared inbox** — Unified view across email, chat, and web form
+
+## Install
+
+```bash
+blueprint install support
+```
+
+## Configuration
+
+| Variable                   | Description                                |
+|----------------------------|--------------------------------------------|
+| `SUPPORT_OPENAI_KEY`       | OpenAI API key for agent responses         |
+| `SUPPORT_INBOX_EMAIL`      | Inbound email address for the support inbox|
+| `SUPPORT_DOCS_URL`         | URL to your Mintlify docs (for AI context) |
+
+## Running
+
+```bash
+pnpm dev:support
+```
+
+App available at `http://localhost:3007`.
+
+## Status
+
+🚧 **Coming Soon** — This app is scaffolded and registered. Full implementation arriving in Phase 2.

--- a/registry/packages/support/manifest.json
+++ b/registry/packages/support/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "support",
+  "name": "Blueprint Support",
+  "version": "0.1.0",
+  "type": "app",
+  "description": "AI-first customer support inbox. Agents handle tier-1, escalate to you. Syncs with docs.",
+  "port": 3007,
+  "appType": "nextjs",
+  "icon": "message-circle",
+  "color": "amber",
+  "subdomain": "support",
+  "envVars": [],
+  "dependencies": [],
+  "postInstall": "pnpm install"
+}


### PR DESCRIPTION
## 🛍️ Blueprint App Store — Phase 1

### What this is

This PR introduces the **Blueprint App Store** — a registry-based system that lets developers discover and install Blueprint apps with a single command. Think `npm install` but for full Blueprint app modules.

Phase 1 ships the foundational plumbing:
- A static `registry/` directory (the "store catalog")
- `blueprint install <id>` — scaffolds an app stub and registers it
- `blueprint list` — shows all available packages

---

### How to install a package

```bash
# See what's available
blueprint list

# Install an app
blueprint install crm
blueprint install pulse
blueprint install support
```

What `blueprint install crm` does:
1. Reads `registry/index.json` (local first, falls back to GitHub raw URL)
2. Finds the package entry for `crm`
3. Prints: `Installing Blueprint CRM (0.1.0)...`
4. Creates `apps/crm/` with a stub `package.json` + `README.md`
5. Appends the entry to `packages/app-config/src/apps-registry.ts`
6. Prints: `✅ Blueprint CRM installed. Run pnpm dev:crm to start it.`

---

### How to contribute a package

1. Fork the repo, create a branch: `registry/your-package-name`
2. Add `registry/packages/your-package/manifest.json` and `README.md`
3. Add your entry to `registry/index.json`
4. Open a PR targeting `allen/os`

Full contribution guide in [`registry/README.md`](./registry/README.md).

---

### First-party packages included

| Package | Port | Description |
|---------|------|-------------|
| `crm` | 3005 | Lightweight customer pipeline — track leads, trials, paid users. Agent-powered follow-ups. |
| `pulse` | 3006 | Unified KPI dashboard — MRR, active users, agent activity, cost per run. The CEO view. |
| `support` | 3007 | AI-first customer support inbox. Agents handle tier-1, escalate to you. Syncs with docs. |

---

### Files changed

```
registry/
├── index.json                    ← Master package list
├── README.md                     ← Contribution guide
└── packages/
    ├── crm/{manifest.json,README.md}
    ├── pulse/{manifest.json,README.md}
    └── support/{manifest.json,README.md}

packages/blueprint-cli/src/
├── commands/install.ts           ← blueprint install <id>
├── commands/list.ts              ← blueprint list
└── index.ts                     ← Wired up both commands
```

### Testing

```bash
# From repo root
cd packages/blueprint-cli && pnpm build
node dist/index.js list
node dist/index.js install crm
```

---

> Phase 2 will ship real app implementations for CRM, Pulse, and Support. Phase 1 is all about the infrastructure.
