### PR TITLE
docs: add App Store and CI/CD documentation

### DIFF
--- a/apps/docs/extending/app-store.mdx
+++ b/apps/docs/extending/app-store.mdx
@@ -1,0 +1,127 @@
+---
+title: "Blueprint App Store"
+description: "Install apps, agents, and skills into your Blueprint instance with a single command"
+---
+
+## What Is the App Store?
+
+The Blueprint App Store is a package registry that lets you extend your Blueprint instance with pre-built apps, agents, and skills. Instead of scaffolding from scratch, you browse available packages and install them with a single CLI command.
+
+When you install a package, Blueprint:
+
+1. Scaffolds the app into `apps/`
+2. Registers it in `packages/app-config/src/apps-registry.ts`
+3. Wires up PM2, Caddy, and the OS desktop automatically
+
+## Browsing Available Packages
+
+List all available packages from the registry:
+
+```bash
+blueprint list
+```
+
+This outputs the current catalog with each package's name, type, and short description.
+
+## Installing a Package
+
+```bash
+blueprint install crm
+```
+
+That's it. Blueprint pulls the manifest, scaffolds the app, and registers it in your OS. After install, build and start it:
+
+```bash
+pnpm build --filter=crm
+pm2 restart crm
+```
+
+## Available Packages
+
+<CardGroup cols={3}>
+  <Card title="CRM" icon="address-book">
+    A customer relationship manager. Track contacts, deals, and follow-ups directly inside your Blueprint OS.
+  </Card>
+  <Card title="Pulse" icon="chart-line">
+    A real-time metrics dashboard. Visualize key business signals and agent activity at a glance.
+  </Card>
+  <Card title="Support" icon="headset">
+    A support ticket system. Manage inbound requests, assign to agents, and track resolution status.
+  </Card>
+</CardGroup>
+
+## What Happens on Install
+
+When you run `blueprint install <package>`, the CLI:
+
+<Steps>
+  <Step title="Fetches the manifest">
+    Pulls `manifest.json` from `registry/packages/<package>/manifest.json` in the Blueprint repo.
+  </Step>
+  <Step title="Scaffolds the app">
+    Creates the app directory under `apps/` with the package's source files and dependencies.
+  </Step>
+  <Step title="Registers in OS">
+    Adds an entry to `packages/app-config/src/apps-registry.ts` so the app appears on the desktop and gets a PM2 process and Caddy reverse proxy.
+  </Step>
+  <Step title="Runs postInstall (if defined)">
+    Executes any post-install commands listed in the manifest (e.g., database migrations).
+  </Step>
+</Steps>
+
+## Contributing a Package
+
+Want to publish your own app to the registry? Open a PR to `registry/packages/` with a `manifest.json` describing your package.
+
+```
+registry/
+└── packages/
+    └── my-app/
+        └── manifest.json
+```
+
+### manifest.json Schema
+
+```json
+{
+  "id": "my-app",
+  "name": "My App",
+  "version": "1.0.0",
+  "type": "app",
+  "description": "Short description shown in blueprint list",
+  "port": 3010,
+  "appType": "nextjs",
+  "icon": "star",
+  "color": "purple",
+  "subdomain": "my-app",
+  "envVars": [
+    {
+      "key": "MY_APP_API_KEY",
+      "description": "API key for My App",
+      "required": true
+    }
+  ],
+  "dependencies": ["@repo/db", "@repo/app-config"],
+  "postInstall": ["pnpm db:push"]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Unique package identifier (used in `blueprint install <id>`) |
+| `name` | `string` | Human-readable display name |
+| `version` | `string` | Semver version string |
+| `type` | `string` | `"app"`, `"agent"`, or `"skill"` |
+| `description` | `string` | One-line description shown in `blueprint list` |
+| `port` | `number` | Local port the app listens on |
+| `appType` | `string` | Scaffold type: `"nextjs"`, `"fastify"`, etc. |
+| `icon` | `string` | Icon name from [Lucide](https://lucide.dev/icons/) |
+| `color` | `string` | Tailwind color name for OS window chrome |
+| `subdomain` | `string` | Subdomain for Caddy reverse proxy |
+| `envVars` | `array` | Required/optional environment variables |
+| `dependencies` | `array` | Workspace packages to link (`workspace:*`) |
+| `postInstall` | `array` | Shell commands to run after scaffolding |
+
+<Tip>
+Keep `port` values above 3100 to avoid conflicts with core Blueprint services. Check `packages/app-config/src/apps-registry.ts` for ports already in use.
+</Tip>

--- a/apps/docs/extending/ci-cd.mdx
+++ b/apps/docs/extending/ci-cd.mdx
@@ -1,0 +1,93 @@
+---
+title: "CI/CD & Quality Gates"
+description: "Automated type checking and linting on every PR to keep the codebase healthy"
+---
+
+## What CI Does
+
+Every pull request targeting `allen/os` runs an automated quality gate via GitHub Actions. The pipeline:
+
+1. Checks out the branch
+2. Installs dependencies with `pnpm install`
+3. Runs **`pnpm check-types`** — TypeScript strict-mode type check across all apps and packages
+4. Runs **`pnpm lint`** — ESLint across the full monorepo
+
+If either check fails, the PR is blocked from merging.
+
+## Why It Matters
+
+Blueprint OS is developed by multiple AI agents pushing code concurrently — Ocean, Arctic, Skylar, Coral, and others. Without an automated gate, type errors and lint violations accumulate quickly across simultaneous branches.
+
+CI acts as the objective referee: every agent's code gets the same check, and no broken code sneaks into the main branch.
+
+## What Runs
+
+### Type Check
+
+```bash
+pnpm check-types
+```
+
+Runs `tsc --noEmit` across the entire monorepo via Turborepo. Catches:
+
+- Missing or wrong types
+- Incorrect prop types on React components
+- Unsafe `any` usage (TypeScript strict mode is on)
+- Import errors (missing modules, wrong paths)
+
+### Lint
+
+```bash
+pnpm lint
+```
+
+Runs ESLint across all apps and packages using the shared config from `packages/eslint-config/`. Catches:
+
+- Unused imports and variables
+- `console.log` left in production code
+- React hooks violations
+- Code style inconsistencies
+
+## PR Template Checklist
+
+Every PR to `allen/os` should cover:
+
+- [ ] `pnpm check-types` passes locally
+- [ ] `pnpm lint` passes locally
+- [ ] Changes are scoped to a single concern
+- [ ] Commit messages follow [conventional commits](/conventions) (`feat:`, `fix:`, `docs:`, etc.)
+- [ ] New pages/routes include mobile viewport testing at 375px
+- [ ] If adding a new app or package: registered in `apps-registry.ts`
+- [ ] If changing the API: Swagger schema updated
+
+## Running Checks Locally
+
+Run the same checks CI runs before opening a PR:
+
+```bash
+# Type check the full monorepo
+pnpm check-types
+
+# Lint the full monorepo
+pnpm lint
+```
+
+To target a single app (faster during development):
+
+```bash
+pnpm check-types --filter=web
+pnpm lint --filter=web
+```
+
+<Tip>
+Run these before every commit. The CI pipeline runs the same commands, so a clean local run means CI will pass.
+</Tip>
+
+## CI Configuration
+
+The workflow lives at `.github/workflows/ci.yml` in the repo root. It triggers on:
+
+- Every `pull_request` targeting `allen/os`
+- Every `push` to `allen/os`
+
+Agents should treat a failing CI check as a blocking issue — fix the types or lint errors before the PR can be reviewed.

--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -102,7 +102,9 @@
         "extending/deploy-pipeline",
         "extending/multi-repo-pipeline",
         "extending/file-storage",
-        "extending/custom-agents"
+        "extending/custom-agents",
+        "extending/app-store",
+        "extending/ci-cd"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Adds two new documentation pages to the Extending section:

- **`extending/app-store.mdx`** — Blueprint App Store: what it is, how to browse/install packages, the 3 available packages (CRM, Pulse, Support), and how to contribute with `manifest.json` schema
- **`extending/ci-cd.mdx`** — CI/CD & Quality Gates: what CI runs, why it matters with multi-agent development, the PR checklist, and how to run checks locally

Also updates `mint.json` navigation to include both pages under the Extending group.

## Checklist
- [x] `pnpm check-types` passes locally (docs only, no TS changes)
- [x] `pnpm lint` passes locally (docs only)
- [x] Changes scoped to a single concern
- [x] Conventional commit used